### PR TITLE
Fix Triton kernel call and update AMP decorators

### DIFF
--- a/stream_attention/core/fused_online_attention.py
+++ b/stream_attention/core/fused_online_attention.py
@@ -302,10 +302,10 @@ class FusedOnlineAttention(nn.Module):
 			output.stride(0), output.stride(2), output.stride(1), output.stride(3),
 			lse.stride(0), lse.stride(1), lse.stride(2),
 			stride_mb, stride_mn,
-			H=self.num_heads, M=seq_len_q, N=seq_len_k, D=self.head_dim,
-			TILE_M=self.tile_size_q, TILE_K=self.head_dim, TILE_N=self.tile_size_k,
-			scale=self.scale, IS_CAUSAL=causal, HAS_MASK=has_mask, num_warps=4, num_stages=2
-		)
+				H=self.num_heads, M=seq_len_q, N=seq_len_k, D=self.head_dim,
+				TILE_K=self.head_dim,
+				scale=self.scale, IS_CAUSAL=causal, HAS_MASK=has_mask
+			)
 		if self.world_size > 1:
 			output_list = [torch.empty_like(output) for _ in range(self.world_size)]
 			dist.all_gather(output_list, output)

--- a/stream_attention/core/ring_attention.py
+++ b/stream_attention/core/ring_attention.py
@@ -262,7 +262,7 @@ class RingAttention(nn.Module):
         
         return combined_output, combined_lse
     
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.float16)
+    @torch.amp.custom_fwd(device_type="cuda", cast_inputs=torch.float16)
     def forward(
         self,
         query: torch.Tensor,

--- a/stream_attention/core/star_attention.py
+++ b/stream_attention/core/star_attention.py
@@ -475,7 +475,7 @@ class StarAttention(nn.Module):
         
         return compressed_key, compressed_value
     
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.float16)
+    @torch.amp.custom_fwd(device_type="cuda", cast_inputs=torch.float16)
     def forward(
         self,
         query: torch.Tensor,


### PR DESCRIPTION
## Summary
- swap deprecated `torch.cuda.amp.custom_fwd` for `torch.amp.custom_fwd` in ring and star attention modules
- drop explicit Triton tile size and launch params to avoid autotune conflicts

## Testing
- `pytest`
- `python - <<'PY' ...` (manual CPU benchmark for fused vs FlashAttention3)


------
https://chatgpt.com/codex/tasks/task_e_68a863c257848322a34146e3b4abfeed