### PR TITLE
Use tl.dot in fused online attention

### DIFF
--- a/stream_attention/core/fused_online_attention.py
+++ b/stream_attention/core/fused_online_attention.py
@@ -129,7 +129,7 @@ if TRITON_AVAILABLE:
 			acc_num *= correction[:, None]
 			acc_den *= correction
 			exp_qk = tl.exp(qk - new_max[:, None])
-			acc_num += exp_qk @ v
+			acc_num += tl.dot(exp_qk, v)
 			acc_den += tl.sum(exp_qk, axis=1)
 			running_max = new_max
 		# Final output


### PR DESCRIPTION
## Summary
- replace matrix multiply `exp_qk @ v` with `tl.dot(exp_qk, v)` in fused online attention kernel to avoid Python 3.12 AST issues

## Testing
- `pytest tests`
- `python -m stream_attention.benchmarks.benchmark_suite --seq 8 --batch 1 --heads 1 --dim 8 --warmup 1 --iters 1` *(fails: 'FusedOnlineAttention' object has no attribute 'benchmark')*

------
https://chatgpt.com/codex/tasks/task_e_68a882078404832289d06a54ed95b505