### PR TITLE
Cast value tile to fp32 in fused online attention kernel

### DIFF
--- a/stream_attention/core/fused_online_attention.py
+++ b/stream_attention/core/fused_online_attention.py
@@ -110,7 +110,7 @@ if TRITON_AVAILABLE:
 			# Load tiles
 			kv_mask = ((start_n + offs_n)[:, None] < N) & (offs_k[None, :] < D)
 			k = tl.load(k_ptrs, mask=kv_mask, other=0.0)
-			v = tl.load(v_ptrs, mask=kv_mask, other=0.0)
+			v = tl.load(v_ptrs, mask=kv_mask, other=0.0).to(tl.float32)
 			# QK^T
 			qk = tl.dot(q, tl.trans(k)) * scale
 			# Causal


### PR DESCRIPTION
## Summary
- load V tiles as float32 to match exp_qk and ensure fp32 accumulation

## Testing
- `pytest tests/test_attention.py::TestStreamAttention::test_flash_attention_correctness -q`
- `python -m stream_attention.benchmarks.benchmark_suite --seq 128 --batch 1 --heads 2 --dim 32 --warmup 1 --iters 1` *(fails: AttributeError: 'FusedOnlineAttention' object has no attribute 'benchmark')*
- `python - <<'PY'
import torch
from stream_attention.core.fused_online_attention import FusedOnlineAttention
num_heads=2
head_dim=32
model=FusedOnlineAttention(num_heads, head_dim, dtype=torch.float16 if torch.cuda.is_available() else torch.float32)
seq_len=64
batch_size=1
q=torch.randn(batch_size, seq_len, num_heads, head_dim, device='cuda' if torch.cuda.is_available() else 'cpu', dtype=model.dtype)
k=torch.randn_like(q)
v=torch.randn_like(q)
out=model(q,k,v)
print('out shape', out.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8866736488322a53b5b9f8b08d19f