### PR TITLE
Cast value tile to fp32 in fused online attention kernel

### DIFF
--- a/stream_attention/core/fused_online_attention.py
+++ b/stream_attention/core/fused_online_attention.py
@@ -110,7 +110,7 @@ if TRITON_AVAILABLE:
 			# Load tiles
 			kv_mask = ((start_n + offs_n)[:, None] < N) & (offs_k[None, :] < D)
 			k = tl.load(k_ptrs, mask=kv_mask, other=0.0)
-			v = tl.load(v_ptrs, mask=kv_mask, other=0.0)
+			v = tl.load(v_ptrs, mask=kv_mask, other=0.0).to(tl.float32)
 			# QK^T
 			qk = tl.dot(q, tl.trans(k)) * scale
 			# Causal
@@ -311,6 +311,33 @@ class FusedOnlineAttention(nn.Module):
 			dist.all_gather(output_list, output)
 			output = torch.cat(output_list, dim=1)
 		return (output, lse) if return_lse else output
+
+	@torch.no_grad()
+	def benchmark(self, seq_len: int, batch_size: int = 1, warmup: int = 10, iterations: int = 100) -> Dict[str, float]:
+		device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+		dtype = self.dtype if device.type == "cuda" else torch.float32
+		nh = self.num_heads
+		hd = self.head_dim
+		q = torch.randn(batch_size, seq_len, nh, hd, device=device, dtype=dtype)
+		k = torch.randn_like(q)
+		v = torch.randn_like(q)
+		for _ in range(warmup):
+			_ = self.forward(q, k, v, causal=True)
+		if device.type == "cuda":
+			torch.cuda.synchronize()
+		import time
+		start = time.time()
+		for _ in range(iterations):
+			_ = self.forward(q, k, v, causal=True)
+		if device.type == "cuda":
+			torch.cuda.synchronize()
+		elapsed = (time.time() - start) / iterations
+		flops = 4.0 * batch_size * nh * seq_len * seq_len * hd
+		tflops = flops / elapsed / 1e12
+		bytes_per_el = torch.tensor([], dtype=dtype).element_size()
+		memory_bytes = 3 * batch_size * seq_len * nh * hd * bytes_per_el
+		bandwidth = memory_bytes / elapsed / 1e9
+		return {"time_ms": elapsed * 1000.0, "tflops": tflops, "bandwidth_gb_s": bandwidth, "seq_len": seq_len, "batch_size": batch_size}
 
 
 class FusedOnlineAttentionAutogradFn(torch.autograd.Function):


### PR DESCRIPTION
## Summary
- load V tiles as float32 to match exp_qk and ensure fp32 accumulation
- add a benchmark method for FusedOnlineAttention so benchmark suite runs

## Testing
- `pytest tests/test_attention.py::TestStreamAttention::test_flash_attention_correctness -q`
- `python -m stream_attention.benchmarks.benchmark_suite --seq 128 --batch 1 --heads 2 --dim 32 --warmup 1 --iters 1`
- `python - <<'PY'
import torch
from stream_attention.core.fused_online_attention import FusedOnlineAttention
num_heads=2
head_dim=32
model=FusedOnlineAttention(num_heads, head_dim, dtype=torch.float16 if torch.cuda.is_available() else torch.float32)
seq_len=64
batch_size=1
device='cuda' if torch.cuda.is_available() else 'cpu'
q=torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=model.dtype)
k=torch.randn_like(q)
v=torch.randn_like(q)
out=model(q,k,v)
print('out shape', out.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8866736488322a53b5b9f8b08d19f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes numerical precision in the fused online attention kernel by casting V tiles to fp32 for correct accumulation, and adds a built-in benchmark to measure performance.

- **Bug Fixes**
  - Load V tiles as float32 in the Triton kernel to match exp/lse path and ensure fp32 accumulation.
  - Prevents precision drift from mixed dtypes during attention computation.

- **New Features**
  - Adds FusedOnlineAttention.benchmark(seq_len, batch_size=1, warmup=10, iterations=100) returning time_ms, tflops, and bandwidth_gb_s.
  - Uses CUDA when available; defaults to fp32 on CPU.

<!-- End of auto-generated description by cubic. -->

