### PR TITLE
Improve benchmarking and flash attention fallback

### DIFF
--- a/stream_attention/benchmarks/benchmark_suite.py
+++ b/stream_attention/benchmarks/benchmark_suite.py
@@ -8,23 +8,50 @@ from stream_attention.core.flashattention_v3 import FlashAttentionV3
 from stream_attention.core.config import StreamAttentionConfig
 
 
+def _benchmark_module(module, seq_len, batch_size, warmup, iterations):
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        dtype = torch.float16 if device.type == "cuda" else torch.float32
+        nh = getattr(module, "num_heads")
+        hd = getattr(module, "head_dim")
+        q = torch.randn(batch_size, seq_len, nh, hd, device=device, dtype=dtype)
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        for _ in range(warmup):
+                module(q, k, v, causal=True)
+        if device.type == "cuda":
+                torch.cuda.synchronize()
+        import time
+        start = time.time()
+        for _ in range(iterations):
+                module(q, k, v, causal=True)
+        if device.type == "cuda":
+                torch.cuda.synchronize()
+        elapsed = (time.time() - start) / iterations
+        flops = 4.0 * batch_size * nh * seq_len * seq_len * hd
+        tflops = flops / elapsed / 1e12
+        bytes_per_el = torch.tensor([], dtype=dtype).element_size()
+        memory_bytes = 3 * batch_size * seq_len * nh * hd * bytes_per_el
+        bandwidth = memory_bytes / elapsed / 1e9
+        return {"time_ms": elapsed * 1000.0, "tflops": tflops, "bandwidth_gb_s": bandwidth}
+
+
 def run_bench(seq_lens: List[int], batch_size: int, num_heads: int, head_dim: int, warmup: int, iters: int) -> Dict[int, Dict[str, float]]:
-	device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-	cfg = StreamAttentionConfig(num_heads=num_heads, head_dim=head_dim, use_fp16=(device.type == "cuda"))
-	fused = FusedOnlineAttention(num_heads=num_heads, head_dim=head_dim, dtype=(torch.float16 if device.type == "cuda" else torch.float32))
-	fa3 = FlashAttentionV3(cfg)
-	results = {}
-	for L in seq_lens:
-		fr = fused.benchmark(seq_len=L, batch_size=batch_size, warmup=warmup, iterations=iters)
-		ar = fa3.benchmark(seq_len=L, batch_size=batch_size, warmup=warmup, iterations=iters)
-		results[L] = {
-			"fused_time_ms": fr["time_ms"],
-			"fused_tflops": fr["tflops"],
-			"fa3_time_ms": ar["time_ms"],
-			"fa3_tflops": ar["tflops"],
-			"speedup_vs_fa3": ar["time_ms"] / fr["time_ms"] if fr["time_ms"] > 0 else float("inf"),
-		}
-	return results
+        cfg = StreamAttentionConfig(num_heads=num_heads, head_dim=head_dim, use_fp16=torch.cuda.is_available())
+        fused = FusedOnlineAttention(num_heads=num_heads, head_dim=head_dim,
+                                     dtype=(torch.float16 if torch.cuda.is_available() else torch.float32))
+        fa3 = FlashAttentionV3(cfg)
+        results = {}
+        for L in seq_lens:
+                fr = _benchmark_module(fused, L, batch_size, warmup, iters)
+                ar = fa3.benchmark(seq_len=L, batch_size=batch_size, warmup=warmup, iterations=iters)
+                results[L] = {
+                        "fused_time_ms": fr["time_ms"],
+                        "fused_tflops": fr["tflops"],
+                        "fa3_time_ms": ar["time_ms"],
+                        "fa3_tflops": ar["tflops"],
+                        "speedup_vs_fa3": ar["time_ms"] / fr["time_ms"] if fr["time_ms"] > 0 else float("inf"),
+                }
+        return results
 
 
 def main():

--- a/stream_attention/core/flashattention_v3.py
+++ b/stream_attention/core/flashattention_v3.py
@@ -9,109 +9,111 @@ logger = logging.getLogger(__name__)
 
 
 def _use_flash_sdpa() -> bool:
-	# Prefer flash kernel on CUDA when available
-	return torch.cuda.is_available()
+    # Prefer flash kernel on CUDA when available
+    return torch.cuda.is_available()
 
 
 class FlashAttentionV3(nn.Module):
-	"""
-	FlashAttention V3 wrapper using PyTorch SDPA backends.
-	
-	- Uses flash-kernel backed scaled_dot_product_attention on CUDA
-	- Falls back to math/mem-efficient kernels elsewhere
-	- API: inputs as [batch, seq_len, num_heads, head_dim]
-	"""
-	def __init__(self, config=None):
-		super().__init__()
-		self.num_heads = getattr(config, "num_heads", None)
-		self.head_dim = getattr(config, "head_dim", None)
-		self.dropout = getattr(config, "dropout", 0.0) or 0.0
-		self.dtype = torch.float16 if getattr(config, "use_fp16", True) else torch.float32
+    """
+    FlashAttention V3 wrapper using PyTorch SDPA backends.
+    
+    - Uses flash-kernel backed scaled_dot_product_attention on CUDA
+    - Falls back to math/mem-efficient kernels elsewhere
+    - API: inputs as [batch, seq_len, num_heads, head_dim]
+    """
+    def __init__(self, config=None):
+        super().__init__()
+        self.num_heads = getattr(config, "num_heads", None)
+        self.head_dim = getattr(config, "head_dim", None)
+        self.dropout = getattr(config, "dropout", 0.0) or 0.0
+        self.dtype = torch.float16 if getattr(config, "use_fp16", True) else torch.float32
 
-	def forward(
-		self,
-		query: torch.Tensor,
-		key: torch.Tensor,
-		value: torch.Tensor,
-		attention_mask: Optional[torch.Tensor] = None,
-		causal: bool = True,
-	) -> torch.Tensor:
-		batch_size, seq_len_q, num_heads_q, head_dim_q = query.shape
-		_, seq_len_kv, num_heads_k, head_dim_k = key.shape
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        causal: bool = True,
+    ) -> torch.Tensor:
+        batch_size, seq_len_q, num_heads_q, head_dim_q = query.shape
+        _, seq_len_kv, num_heads_k, head_dim_k = key.shape
 
-		assert num_heads_q == num_heads_k, "Mismatched heads"
-		assert head_dim_q == head_dim_k, "Mismatched head dim"
+        assert num_heads_q == num_heads_k, "Mismatched heads"
+        assert head_dim_q == head_dim_k, "Mismatched head dim"
 
-		# Merge batch and heads for SDPA
-		q = query.permute(0, 2, 1, 3).reshape(batch_size * num_heads_q, seq_len_q, head_dim_q)
-		k = key.permute(0, 2, 1, 3).reshape(batch_size * num_heads_q, seq_len_kv, head_dim_q)
-		v = value.permute(0, 2, 1, 3).reshape(batch_size * num_heads_q, seq_len_kv, head_dim_q)
+        # Prepare inputs for SDPA: [B, H, L, D]
+        q = query.permute(0, 2, 1, 3)
+        k = key.permute(0, 2, 1, 3)
+        v = value.permute(0, 2, 1, 3)
 
-		if attention_mask is not None:
-			# Expect mask broadcastable to [B*H, Q, K]
-			# Convert boolean mask to additive mask if needed
-			if attention_mask.dtype == torch.bool:
-				attn_mask = torch.where(attention_mask, 0.0, float("-inf")).to(q.dtype)
-			else:
-				attn_mask = attention_mask
-		else:
-			attn_mask = None
+        attn_mask = None
+        if attention_mask is not None:
+            if attention_mask.dtype == torch.bool:
+                mask = torch.where(attention_mask, 0.0, float('-inf')).to(q.dtype)
+            else:
+                mask = attention_mask.to(q.dtype)
+            if mask.dim() == 2:
+                attn_mask = mask[:, None, None, :]
+            elif mask.dim() == 3:
+                attn_mask = mask[:, None, :, :]
+            else:
+                attn_mask = mask
 
-		# Handle CPU dtype limitations
-		cpu_cast_back = None
-		if q.device.type == 'cpu' and q.dtype in (torch.float16, torch.bfloat16):
-			cpu_cast_back = q.dtype
-			q = q.float(); k = k.float(); v = v.float()
-			if attn_mask is not None:
-				attn_mask = attn_mask.float()
+        cpu_cast_back = None
+        if q.device.type == 'cpu' and q.dtype in (torch.float16, torch.bfloat16):
+            cpu_cast_back = q.dtype
+            q = q.float(); k = k.float(); v = v.float()
+            if attn_mask is not None:
+                attn_mask = attn_mask.float()
 
-		if _use_flash_sdpa() and q.device.type == 'cuda':
-			# Use flash kernel; disable other kernels to force flash on CUDA
-			with torch.backends.cuda.sdp_kernel(enable_math=False, enable_flash=True, enable_mem_efficient=False):
-				out = F.scaled_dot_product_attention(q, k, v, attn_mask, dropout_p=self.dropout if self.training else 0.0, is_causal=causal)
-		else:
-			# CPU or non-CUDA path; let PyTorch pick the best available
-			out = F.scaled_dot_product_attention(q, k, v, attn_mask, dropout_p=self.dropout if self.training else 0.0, is_causal=causal)
+        if _use_flash_sdpa() and q.device.type == 'cuda':
+            try:
+                with torch.nn.attention.sdpa_kernel(enable_flash=True):
+                    out = F.scaled_dot_product_attention(q, k, v, attn_mask, dropout_p=self.dropout if self.training else 0.0, is_causal=causal)
+            except RuntimeError:
+                out = F.scaled_dot_product_attention(q, k, v, attn_mask, dropout_p=self.dropout if self.training else 0.0, is_causal=causal)
+        else:
+            out = F.scaled_dot_product_attention(q, k, v, attn_mask, dropout_p=self.dropout if self.training else 0.0, is_causal=causal)
 
-		if cpu_cast_back is not None:
-			out = out.to(cpu_cast_back)
+        if cpu_cast_back is not None:
+            out = out.to(cpu_cast_back)
 
-		# Reshape back to [B, Q, H, D]
-		out = out.reshape(batch_size, num_heads_q, seq_len_q, head_dim_q).permute(0, 2, 1, 3).contiguous()
-		return out
+        out = out.permute(0, 2, 1, 3).contiguous()
+        return out
 
-	@torch.no_grad()
-	def benchmark(self, seq_len: int, batch_size: int = 1, warmup: int = 10, iterations: int = 100) -> Dict[str, float]:
-		device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-		dtype = self.dtype if device.type == "cuda" else torch.float32
+    @torch.no_grad()
+    def benchmark(self, seq_len: int, batch_size: int = 1, warmup: int = 10, iterations: int = 100) -> Dict[str, float]:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        dtype = self.dtype if device.type == "cuda" else torch.float32
 
-		nh = self.num_heads or 8
-		hd = self.head_dim or 64
+        nh = self.num_heads or 8
+        hd = self.head_dim or 64
 
-		q = torch.randn(batch_size, seq_len, nh, hd, device=device, dtype=dtype)
-		k = torch.randn(batch_size, seq_len, nh, hd, device=device, dtype=dtype)
-		v = torch.randn(batch_size, seq_len, nh, hd, device=device, dtype=dtype)
+        q = torch.randn(batch_size, seq_len, nh, hd, device=device, dtype=dtype)
+        k = torch.randn(batch_size, seq_len, nh, hd, device=device, dtype=dtype)
+        v = torch.randn(batch_size, seq_len, nh, hd, device=device, dtype=dtype)
 
-		# Warmup
-		for _ in range(warmup):
-			_ = self.forward(q, k, v, causal=True)
+        # Warmup
+        for _ in range(warmup):
+            _ = self.forward(q, k, v, causal=True)
 
-		if device.type == "cuda":
-			torch.cuda.synchronize()
+        if device.type == "cuda":
+            torch.cuda.synchronize()
 
-		import time
-		start = time.time()
-		for _ in range(iterations):
-			_ = self.forward(q, k, v, causal=True)
-		if device.type == "cuda":
-			torch.cuda.synchronize()
-		elapsed = (time.time() - start) / iterations
+        import time
+        start = time.time()
+        for _ in range(iterations):
+            _ = self.forward(q, k, v, causal=True)
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        elapsed = (time.time() - start) / iterations
 
-		# FLOPS: 4 * B * H * Q * K * D approximately for attention
-		flops = 4.0 * batch_size * (self.num_heads or nh) * seq_len * seq_len * (self.head_dim or hd)
-		tflops = flops / elapsed / 1e12
-		bytes_per_el = torch.tensor([], dtype=dtype).element_size()
-		memory_bytes = 3 * batch_size * seq_len * (self.num_heads or nh) * (self.head_dim or hd) * bytes_per_el
-		bandwidth = memory_bytes / elapsed / 1e9
+        # FLOPS: 4 * B * H * Q * K * D approximately for attention
+        flops = 4.0 * batch_size * (self.num_heads or nh) * seq_len * seq_len * (self.head_dim or hd)
+        tflops = flops / elapsed / 1e12
+        bytes_per_el = torch.tensor([], dtype=dtype).element_size()
+        memory_bytes = 3 * batch_size * seq_len * (self.num_heads or nh) * (self.head_dim or hd) * bytes_per_el
+        bandwidth = memory_bytes / elapsed / 1e9
 
-		return {"time_ms": elapsed * 1000.0, "tflops": tflops, "bandwidth_gb_s": bandwidth, "seq_len": seq_len, "batch_size": batch_size}
+        return {"time_ms": elapsed * 1000.0, "tflops": tflops, "bandwidth_gb_s": bandwidth, "seq_len": seq_len, "batch_size": batch_size}

--- a/stream_attention/core/ring_attention.py
+++ b/stream_attention/core/ring_attention.py
@@ -262,7 +262,7 @@ class RingAttention(nn.Module):
         
         return combined_output, combined_lse
     
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.float16)
+    @torch.amp.custom_fwd(device_type="cuda", cast_inputs=torch.float16)
     def forward(
         self,
         query: torch.Tensor,

--- a/stream_attention/core/star_attention.py
+++ b/stream_attention/core/star_attention.py
@@ -475,7 +475,7 @@ class StarAttention(nn.Module):
         
         return compressed_key, compressed_value
     
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.float16)
+    @torch.amp.custom_fwd(device_type="cuda", cast_inputs=torch.float16)
     def forward(
         self,
         query: torch.Tensor,


### PR DESCRIPTION
## Summary
- ensure fused kernel operates in fp32 for V tile and dot products
- use torch.nn.attention.sdpa_kernel with graceful fallback in FlashAttentionV3
- add generic benchmark helper to compare fused attention with FlashAttention-3

## Testing
- `pytest stream_attention/benchmarks/accuracy_test.py tests/test_attention.py -q`
- `python -m stream_attention.benchmarks.benchmark_suite --seq 512 1024 --warmup 1 --iters 1`


------
https://chatgpt.com/codex/tasks/task_e_68a863c257848322a34146e3b4abfeed
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a generic benchmark to compare FusedOnlineAttention with FlashAttention-3 and makes FlashAttention V3 fallback robust across devices. Also improves numeric stability in the fused kernel and updates AMP usage for PyTorch 2.x.

- **New Features**
  - Added a shared _benchmark_module helper and integrated it into run_bench for fused attention.
  - Reports time, TFLOPs, bandwidth, and speedup vs FA3 with consistent dtype/device handling.

- **Bug Fixes**
  - FlashAttentionV3 now uses torch.nn.attention.sdpa_kernel(enable_flash=True) with graceful fallback; improved mask broadcasting and safe CPU casting.
  - Fused kernel computes V tiles and dot products in fp32 and switches to tl.dot for stability/accuracy.
  - Updated AMP decorators to torch.amp.custom_fwd(device_type="cuda") for PyTorch 2.x compatibility.

<!-- End of auto-generated description by cubic. -->

