### PR TITLE
Clean benchmark timing path

### DIFF
--- a/stream_attention/benchmarks/benchmark_suite.py
+++ b/stream_attention/benchmarks/benchmark_suite.py
@@ -37,20 +37,16 @@ def _benchmark_module(module, seq_len, batch_size, warmup, iterations):
 
 def run_bench(seq_lens: List[int], batch_size: int, num_heads: int, head_dim: int, warmup: int, iters: int) -> Dict[int, Dict[str, float]]:
         cfg = StreamAttentionConfig(num_heads=num_heads, head_dim=head_dim, use_fp16=torch.cuda.is_available())
-        fused = FusedOnlineAttention(num_heads=num_heads, head_dim=head_dim,
-                                     dtype=(torch.float16 if torch.cuda.is_available() else torch.float32))
+        fused = FusedOnlineAttention(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            dtype=(torch.float16 if torch.cuda.is_available() else torch.float32),
+        )
         fa3 = FlashAttentionV3(cfg)
         results = {}
         for L in seq_lens:
-
-                fr = fused.benchmark(seq_len=L, batch_size=batch_size, warmup=warmup, iterations=iters)
-
-
-                fr = fused.benchmark(seq_len=L, batch_size=batch_size, warmup=warmup, iterations=iters)
-
                 fr = _benchmark_module(fused, L, batch_size, warmup, iters)
-
-                ar = fa3.benchmark(seq_len=L, batch_size=batch_size, warmup=warmup, iterations=iters)
+                ar = _benchmark_module(fa3, L, batch_size, warmup, iters)
                 results[L] = {
                         "fused_time_ms": fr["time_ms"],
                         "fused_tflops": fr["tflops"],

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,41 @@
+import sys
+import types
+
+import pytest
+import torch
+
+
+class _DummyFused:
+    def __init__(self, num_heads, head_dim, dtype=None):
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+
+    def __call__(self, q, k, v, causal=True):  # pragma: no cover
+        return q + k + v
+
+
+def _create_dummy_fused(*args, **kwargs):  # pragma: no cover
+    return _DummyFused(*args, **kwargs)
+
+
+# Stub out the heavy Triton-dependent module before importing benchmark_suite
+stub = types.ModuleType("fused_online_attention")
+stub.FusedOnlineAttention = _DummyFused
+stub.create_fused_online_attention = _create_dummy_fused
+sys.modules.setdefault("stream_attention.core.fused_online_attention", stub)
+
+from stream_attention.benchmarks.benchmark_suite import run_bench
+
+
+def test_benchmark_output_keys_and_speedup():
+    res = run_bench([4], batch_size=1, num_heads=2, head_dim=4, warmup=0, iters=1)
+    r = res[4]
+    assert set(r.keys()) == {
+        "fused_time_ms",
+        "fused_tflops",
+        "fa3_time_ms",
+        "fa3_tflops",
+        "speedup_vs_fa3",
+    }
+    expected = r["fa3_time_ms"] / r["fused_time_ms"] if r["fused_time_ms"] > 0 else float("inf")
+    assert pytest.approx(expected) == r["speedup_vs_fa3"]


### PR DESCRIPTION
## Summary
- remove duplicated benchmark calls and use `_benchmark_module` for both StreamAttention and FlashAttention
- add regression test ensuring benchmark outputs and speedup ratio

## Testing
- `pytest tests/test_benchmark.py -q`
- `pytest -q` *(fails: ModuleNotFoundError and TabError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c33c262883228c86456d2d42638b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Deduplicates the benchmark timing path by routing both FusedOnlineAttention and FlashAttentionV3 through _benchmark_module for consistent measurements and correct speedup. Adds a lightweight regression test that stubs Triton deps and verifies output keys and the speedup ratio.

- **Bug Fixes**
  - Removed duplicate fused.benchmark call in run_bench.
  - Use _benchmark_module for both fused and fa3 to unify timing and results.

<!-- End of auto-generated description by cubic. -->

