### PR TITLE
Use SDPBackend enum for flash attention

### DIFF
--- a/stream_attention/core/flashattention_v3.py
+++ b/stream_attention/core/flashattention_v3.py
@@ -80,34 +80,8 @@ class FlashAttentionV3(nn.Module):
         if _use_flash_sdpa() and q.device.type == "cuda":
             try:
                 # Prefer the newer torch.nn.attention API when available
-
-                sdpa_ctx = torch.nn.attention.sdpa_kernel(enable_flash=True)
-
-                try:
-                    if SDPBackend is None:
-                        raise TypeError
-                    with torch.nn.attention.sdpa_kernel(SDPBackend.FLASH_ATTENTION):
-                        out = F.scaled_dot_product_attention(
-                            q,
-                            k,
-                            v,
-                            attn_mask,
-                            dropout_p=self.dropout if self.training else 0.0,
-                            is_causal=causal,
-                        )
-                except TypeError:
-                    # Older PyTorch versions use flag-based arguments
-                    with torch.nn.attention.sdpa_kernel(enable_flash=True):
-                        out = F.scaled_dot_product_attention(
-                            q,
-                            k,
-                            v,
-                            attn_mask,
-                            dropout_p=self.dropout if self.training else 0.0,
-                            is_causal=causal,
-                        )
-
-            except AttributeError:
+                sdpa_ctx = torch.nn.attention.sdpa_kernel(SDPBackend.FLASH_ATTENTION)
+            except (AttributeError, TypeError):
                 try:
                     # Older PyTorch versions expose the context in torch.backends
                     sdpa_ctx = torch.backends.cuda.sdp_kernel(


### PR DESCRIPTION
## Summary
- simplify FlashAttentionV3 to use `torch.nn.attention.SDPBackend.FLASH_ATTENTION`
- fall back to `torch.backends.cuda.sdp_kernel` for older PyTorch

## Testing
- `pytest tests/test_attention.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d60a72c08322b5784ae40b8dec65
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use torch.nn.attention.SDPBackend.FLASH_ATTENTION in FlashAttentionV3 and remove the old flag-based path to simplify the code. If the new API isn’t available, fall back to torch.backends.cuda.sdp_kernel to keep older PyTorch versions working.

<!-- End of auto-generated description by cubic. -->

