### PR TITLE
Add pyproject and CI wheel build configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# Build configuration
+TORCH_CUDA_ARCH_LIST=80;90
+CUDA_HOME=/usr/local/cuda
+CUDA_CACHE_PATH={HOME}/.cache/stream_attn/cuda
+TRITON_CACHE_DIR={HOME}/.cache/stream_attn/triton
+
 # StreamAttention environment configuration example
 # Copy to .env and edit as needed
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build Wheels
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sm: [80, 90]
+    env:
+      TORCH_CUDA_ARCH_LIST: ${{ matrix.sm }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build wheel
+        run: |
+          python -m build --wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = [
+    "setuptools>=61",
+    "wheel",
+    "torch==2.1.0",
+    "triton==2.1.0",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "stream-attention"
+version = "1.0.0"
+description = "Production-ready multi-GPU FlashAttention implementation with support for extremely long contexts"
+authors = [{name = "StreamAttention Team", email = "streamattention@example.com"}]
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+dependencies = [
+    "torch==2.1.0",
+    "triton==2.1.0",
+]
+
+[tool.stream_attention]
+cuda_version = "12.1"
+triton_version = "2.1.0"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with pinned CUDA and Triton build requirements
- expand `.env.example` with GPU arch flags and cache paths
- set up CI workflow to build wheels for SM80 and SM90

## Testing
- `pytest` *(fails: TabError, ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6a20aff08322808d5c4d81ddc7fd