### PR TITLE
Use torch.nn.attention sdpa_kernel API

### DIFF
--- a/stream_attention/core/flashattention_v3.py
+++ b/stream_attention/core/flashattention_v3.py
@@ -100,23 +100,7 @@ class FlashAttentionV3(nn.Module):
                     )
                     sdpa_ctx = nullcontext()
 
-        try:
-            with sdpa_ctx:
-                out = F.scaled_dot_product_attention(
-                    q,
-                    k,
-                    v,
-                    attn_mask,
-                    dropout_p=self.dropout if self.training else 0.0,
-                    is_causal=causal,
-                )
-        except RuntimeError as e:  # pragma: no cover - device/kernel dependent
-            # If a forced-flash configuration leads to "no available kernel",
-            # retry without any forced backend so PyTorch can choose a valid one.
-            logger.debug(
-                "FlashAttention SDPA failed under forced settings, retrying default: %s",
-                e,
-            )
+        with sdpa_ctx:
             out = F.scaled_dot_product_attention(
                 q,
                 k,


### PR DESCRIPTION
## Summary
- switch FlashAttentionV3 to `torch.nn.attention.sdpa_kernel` with flash backend and CUDA fallback
- simplify wrapper to compute SDPA once
- migrate fused online attention to the new SDPA context manager with legacy fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab745edc4483229d99bc35f2dcc2af