### PR TITLE
Streaming backward

### DIFF
--- a/stream_attention/core/fused_online_attention.py
+++ b/stream_attention/core/fused_online_attention.py
@@ -209,7 +209,7 @@ if TRITON_AVAILABLE:
 
             # Online softmax update with fully masked-row safeguards
             tile_max = tl.max(qk, axis=1)
-            prev_valid = has_valid.to(tl.int1) > 0
+            prev_valid = has_valid > 0
             tile_valid = tile_max > float("-inf")
             new_valid = prev_valid | tile_valid
 

--- a/stream_attention/core/fused_online_attention.py
+++ b/stream_attention/core/fused_online_attention.py
@@ -154,7 +154,7 @@ if TRITON_AVAILABLE:
         running_max = tl.full([TILE_M], value=-float("inf"), dtype=tl.float32)
         acc_num = tl.zeros([TILE_M, D], dtype=tl.float32)
         acc_den = tl.zeros([TILE_M], dtype=tl.float32)
-        has_valid = tl.zeros([TILE_M], dtype=tl.int32)
+        has_valid = tl.zeros([TILE_M], dtype=tl.float32)
 
         # Iterate over K/V tiles
         for start_n in range(0, N, TILE_N):
@@ -224,7 +224,7 @@ if TRITON_AVAILABLE:
 
             qk_shifted = qk - safe_new[:, None]
             exp_qk = tl.where(new_valid[:, None], tl.exp(qk_shifted), 0.0)
-            has_valid = new_valid.to(tl.int32)
+            has_valid = new_valid.to(tl.float32)
             
             if HAS_DROPOUT:
                 bh = off_b * H + off_h


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved masked-row handling in Triton fused online attention so masks and softmax match PyTorch SDPA and avoid NaNs on fully masked rows. Backward now receives the correct tile sizes; tests use a portable SDPA math context for parity.

- **Bug Fixes**
  - Added explicit validity tracking in online softmax; cast q/k/v and mask to float32; apply corrections and exp only to valid rows.
  - Convert boolean attention_mask to -inf bias and load mask as qk dtype; keep fully masked rows at zero output with safe denominators.
  - Replaced tl.isfinite with lse > -inf in backward and gated grad_output by row validity.
  - Supplied TILE_M/TILE_N to the backward kernel and removed TILE_K from signatures and call sites.

<!-- End of auto-generated description by cubic. -->

