### PR TITLE
Streaming backward

### DIFF
--- a/benchmarks/certified_attention_probe.py
+++ b/benchmarks/certified_attention_probe.py
@@ -1,0 +1,135 @@
+"""Probe certified attention skip rates and error bounds.
+
+This script is intentionally small and dependency-light. It is meant to answer
+one question before kernel work: do the block summaries produce useful skip
+rates for a given activation pattern and error budget?
+"""
+
+import argparse
+import time
+
+import torch
+
+from stream_attention.certified import certified_attention
+
+
+def _make_inputs(args, device):
+    dtype = torch.float32
+    q = torch.randn(args.batch, args.seq_q, args.heads, args.dim, device=device, dtype=dtype)
+    k = torch.randn(args.batch, args.seq_k, args.heads, args.dim, device=device, dtype=dtype)
+    v = torch.randn(args.batch, args.seq_k, args.heads, args.dim, device=device, dtype=dtype)
+
+    if args.pattern == "peaked":
+        q.zero_()
+        k.zero_()
+        q[..., 0] = args.peak
+        first = min(args.block_size, args.seq_k)
+        k[:, :first, :, 0] = args.peak
+        k[:, first:, :, 0] = -args.peak
+    elif args.pattern == "local":
+        q.zero_()
+        k.zero_()
+        q[..., 0] = args.peak
+        for start in range(0, args.seq_k, args.block_size):
+            end = min(start + args.block_size, args.seq_k)
+            sign = 1.0 if (start // args.block_size) % 4 == 0 else -1.0
+            k[:, start:end, :, 0] = sign * args.peak
+
+    return q, k, v
+
+
+def _sync(device):
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+
+
+def _time_call(fn, device, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    _sync(device)
+    start = time.perf_counter()
+    result = None
+    for _ in range(iters):
+        result = fn()
+    _sync(device)
+    return result, (time.perf_counter() - start) / iters
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seq-q", type=int, default=512)
+    parser.add_argument("--seq-k", type=int, default=512)
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--heads", type=int, default=8)
+    parser.add_argument("--dim", type=int, default=64)
+    parser.add_argument("--block-size", type=int, default=64)
+    parser.add_argument("--error-budget", type=float, default=1e-3)
+    parser.add_argument("--skip-predicate", choices=["mass", "value_bound"], default="value_bound")
+    parser.add_argument("--block-order", choices=["sequential", "reverse", "sink_local", "summary_desc"], default="sequential")
+    parser.add_argument("--num-summary-outliers", type=int, default=0)
+    parser.add_argument("--post-qk-threshold", type=float, default=0.0)
+    parser.add_argument("--disable-summary-gate", dest="enable_summary_gate", action="store_false")
+    parser.add_argument("--disable-post-qk-gate", dest="enable_post_qk_gate", action="store_false")
+    parser.add_argument("--pattern", choices=["random", "peaked", "local"], default="peaked")
+    parser.add_argument("--peak", type=float, default=8.0)
+    parser.add_argument("--causal", action="store_true")
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--iters", type=int, default=5)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    q, k, v = _make_inputs(args, device)
+
+    exact_fn = lambda: certified_attention(
+        q,
+        k,
+        v,
+        causal=args.causal,
+        error_budget=0.0,
+        block_size=args.block_size,
+        skip_predicate=args.skip_predicate,
+        block_order=args.block_order,
+        num_summary_outliers=args.num_summary_outliers,
+        enable_summary_gate=args.enable_summary_gate,
+        enable_post_qk_gate=args.enable_post_qk_gate,
+        post_qk_threshold=args.post_qk_threshold,
+        return_stats=True,
+    )
+    cert_fn = lambda: certified_attention(
+        q,
+        k,
+        v,
+        causal=args.causal,
+        error_budget=args.error_budget,
+        block_size=args.block_size,
+        skip_predicate=args.skip_predicate,
+        block_order=args.block_order,
+        num_summary_outliers=args.num_summary_outliers,
+        enable_summary_gate=args.enable_summary_gate,
+        enable_post_qk_gate=args.enable_post_qk_gate,
+        post_qk_threshold=args.post_qk_threshold,
+        return_stats=True,
+    )
+
+    exact, exact_s = _time_call(exact_fn, device, args.warmup, args.iters)
+    cert, cert_s = _time_call(cert_fn, device, args.warmup, args.iters)
+
+    err = torch.linalg.vector_norm(cert.output - exact.output, dim=-1)
+    print(f"device={device.type} pattern={args.pattern} causal={args.causal}")
+    print(f"shape=batch:{args.batch} seq_q:{args.seq_q} seq_k:{args.seq_k} heads:{args.heads} dim:{args.dim}")
+    print(f"block_size={args.block_size} error_budget={args.error_budget:g}")
+    print(f"skip_predicate={args.skip_predicate} block_order={args.block_order} outliers={args.num_summary_outliers}")
+    print(f"exact_time_ms={exact_s * 1000:.3f}")
+    print(f"certified_time_ms={cert_s * 1000:.3f}")
+    print(f"skip_fraction={cert.stats.skip_fraction:.4f}")
+    print(f"skipped_row_blocks={cert.stats.skipped_row_blocks}")
+    print(f"skipped_pre_k_row_blocks={cert.stats.skipped_pre_k_row_blocks}")
+    print(f"skipped_post_qk_row_blocks={cert.stats.skipped_post_qk_row_blocks}")
+    print(f"computed_row_blocks={cert.stats.computed_row_blocks}")
+    print(f"max_observed_error={err.max().item():.6g}")
+    print(f"max_error_bound={cert.stats.max_error_bound:.6g}")
+    print(f"mean_error_bound={cert.stats.mean_error_bound:.6g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/modal_certified_smoke.py
+++ b/benchmarks/modal_certified_smoke.py
@@ -1,0 +1,80 @@
+"""Modal smoke test for the experimental Triton certified forward kernel."""
+
+import modal
+
+
+app = modal.App("streamattn-certified-smoke")
+
+image = (
+    modal.Image.from_registry("pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel")
+    .pip_install("triton==3.1.0")
+    .add_local_dir(".", remote_path="/root/StreamAttn", copy=True)
+)
+
+
+@app.function(image=image, gpu="A10G", timeout=600)
+def smoke():
+    import sys
+
+    sys.path.insert(0, "/root/StreamAttn")
+
+    import torch
+
+    from stream_attention.certified import certified_attention
+    from stream_attention.kernels.certified_fwd_triton import (
+        certified_attention_triton_forward,
+    )
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    def run_case(name, q, k, v, budget):
+        ref = certified_attention(
+            q,
+            k,
+            v,
+            causal=False,
+            error_budget=0.0,
+            block_size=16,
+        )
+        out, raw_stats = certified_attention_triton_forward(
+            q,
+            k,
+            v,
+            causal=False,
+            error_budget=budget,
+            block_size=16,
+            tile_size_q=16,
+            skip_predicate="value_bound",
+            return_raw_stats=True,
+        )
+        torch.cuda.synchronize()
+        return {
+            "name": name,
+            "max_abs_error": torch.max(torch.abs(out - ref)).item(),
+            "raw_stats": raw_stats.detach().cpu().tolist(),
+        }
+
+    q = torch.randn(1, 64, 2, 32, device=device, dtype=torch.float16)
+    k = torch.randn(1, 64, 2, 32, device=device, dtype=torch.float16)
+    v = torch.randn(1, 64, 2, 32, device=device, dtype=torch.float16)
+    exact_case = run_case("random_exact", q, k, v, 0.0)
+
+    q2 = torch.zeros(1, 64, 2, 32, device=device, dtype=torch.float16)
+    k2 = torch.zeros(1, 64, 2, 32, device=device, dtype=torch.float16)
+    v2 = torch.randn(1, 64, 2, 32, device=device, dtype=torch.float16)
+    q2[..., 0] = 8.0
+    k2[:, :16, :, 0] = 8.0
+    k2[:, 16:, :, 0] = -8.0
+    skip_case = run_case("peaked_certified", q2, k2, v2, 1e-3)
+
+    return {
+        "torch": torch.__version__,
+        "device": torch.cuda.get_device_name(0),
+        "cases": [exact_case, skip_case],
+    }
+
+
+@app.local_entrypoint()
+def main():
+    print(smoke.remote())

--- a/benchmarks/modal_gate1_smoke.py
+++ b/benchmarks/modal_gate1_smoke.py
@@ -1,0 +1,131 @@
+"""Modal smoke test for the Gate-1 Triton forward kernel."""
+
+import modal
+
+
+app = modal.App("streamattn-gate1-smoke")
+
+image = (
+    modal.Image.from_registry("pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel")
+    .pip_install("triton==3.1.0")
+    .add_local_dir(".", remote_path="/root/StreamAttn", copy=True)
+)
+
+
+@app.function(image=image, gpu="A10G", timeout=600)
+def smoke():
+    import sys
+
+    sys.path.insert(0, "/root/StreamAttn")
+
+    import torch
+
+    from stream_attention.certified import certified_attention
+    from stream_attention.kernels.gate1_fwd_triton import (
+        gate1_attention_triton_forward,
+    )
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    def run_case(name, q, k, v, budget):
+        ref = certified_attention(
+            q,
+            k,
+            v,
+            causal=False,
+            error_budget=budget,
+            block_size=16,
+            enable_summary_gate=False,
+            enable_post_qk_gate=True,
+            skip_predicate="value_bound",
+        )
+        out, raw_stats = gate1_attention_triton_forward(
+            q,
+            k,
+            v,
+            causal=False,
+            error_budget=budget,
+            block_size=16,
+            tile_size_q=16,
+            skip_predicate="value_bound",
+            return_raw_stats=True,
+        )
+        torch.cuda.synchronize()
+        return {
+            "name": name,
+            "max_abs_error": torch.max(torch.abs(out - ref)).item(),
+            "raw_stats": raw_stats.detach().cpu().tolist(),
+        }
+
+    q = torch.randn(1, 64, 2, 32, device=device, dtype=torch.float16)
+    k = torch.randn(1, 64, 2, 32, device=device, dtype=torch.float16)
+    v = torch.randn(1, 64, 2, 32, device=device, dtype=torch.float16)
+    exact_case = run_case("random_exact", q, k, v, 0.0)
+
+    q2 = torch.zeros(1, 64, 2, 32, device=device, dtype=torch.float16)
+    k2 = torch.zeros(1, 64, 2, 32, device=device, dtype=torch.float16)
+    v2 = torch.randn(1, 64, 2, 32, device=device, dtype=torch.float16)
+    q2[..., 0] = 8.0
+    k2[:, :16, :, 0] = 8.0
+    k2[:, 16:, :, 0] = -8.0
+    skip_case = run_case("peaked_gate1", q2, k2, v2, 1e-3)
+
+    def time_gate1(q, k, v, budget, iters=20):
+        for _ in range(5):
+            gate1_attention_triton_forward(
+                q,
+                k,
+                v,
+                causal=False,
+                error_budget=budget,
+                block_size=64,
+                tile_size_q=64,
+                skip_predicate="value_bound",
+                return_raw_stats=False,
+            )
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            gate1_attention_triton_forward(
+                q,
+                k,
+                v,
+                causal=False,
+                error_budget=budget,
+                block_size=64,
+                tile_size_q=64,
+                skip_predicate="value_bound",
+                return_raw_stats=False,
+            )
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / iters
+
+    qb = torch.zeros(1, 1024, 4, 64, device=device, dtype=torch.float16)
+    kb = torch.zeros(1, 1024, 4, 64, device=device, dtype=torch.float16)
+    vb = torch.randn(1, 1024, 4, 64, device=device, dtype=torch.float16)
+    qb[..., 0] = 8.0
+    kb[:, :64, :, 0] = 8.0
+    kb[:, 64:, :, 0] = -8.0
+    exact_ms = time_gate1(qb, kb, vb, 0.0)
+    skip_ms = time_gate1(qb, kb, vb, 1e-3)
+
+    return {
+        "torch": torch.__version__,
+        "device": torch.cuda.get_device_name(0),
+        "cases": [exact_case, skip_case],
+        "timing": {
+            "shape": "B1_S1024_H4_D64",
+            "exact_ms": exact_ms,
+            "gate1_ms": skip_ms,
+            "speedup": exact_ms / skip_ms,
+        },
+    }
+
+
+@app.local_entrypoint()
+def main():
+    print(smoke.remote())

--- a/stream_attention/__init__.py
+++ b/stream_attention/__init__.py
@@ -25,6 +25,13 @@ from .core.fused_online_attention import (
 from .core.attention import StreamAttention
 from .core.multihead_attention import StreamMultiheadAttention, create_stream_attention
 from .core.flashattention_v3 import FlashAttentionV3
+from .certified import (
+    BlockSummaries,
+    CertifiedAttentionOutput,
+    CertifiedAttentionStats,
+    build_block_summaries,
+    certified_attention,
+)
 
 # Utilities
 from .utils.memory import (
@@ -41,9 +48,14 @@ __all__ = [
     "FusedOnlineAttention",
     "StreamAttentionConfig",
     "FlashAttentionV3",
+    "BlockSummaries",
+    "CertifiedAttentionOutput",
+    "CertifiedAttentionStats",
     # Factory functions
     "create_stream_attention",
     "create_fused_online_attention",
+    "build_block_summaries",
+    "certified_attention",
     # Utilities
     "MemoryProfiler",
     "create_kv_compressor",

--- a/stream_attention/certified/__init__.py
+++ b/stream_attention/certified/__init__.py
@@ -1,0 +1,22 @@
+"""Certified single-GPU attention prototypes.
+
+This package contains PyTorch reference implementations for the certified
+streaming-attention path. These functions are intentionally kernel-free so the
+math and telemetry can be validated before Triton/CUDA work.
+"""
+
+from .attention import (
+    CertifiedAttentionOutput,
+    CertifiedAttentionStats,
+    certified_attention,
+)
+from .summaries import BlockSummaries, build_block_summaries
+
+__all__ = [
+    "BlockSummaries",
+    "CertifiedAttentionOutput",
+    "CertifiedAttentionStats",
+    "build_block_summaries",
+    "certified_attention",
+]
+

--- a/stream_attention/certified/attention.py
+++ b/stream_attention/certified/attention.py
@@ -1,0 +1,315 @@
+"""Single-GPU certified attention prototype."""
+
+from dataclasses import dataclass
+import math
+from typing import Literal, Optional, Union
+
+import torch
+
+from .bounds import block_score_upper_bound
+from .reorder import BlockOrder, resolve_block_order
+from .summaries import BlockSummaries, build_block_summaries
+
+
+@dataclass(frozen=True)
+class CertifiedAttentionStats:
+    """Telemetry from certified attention."""
+
+    skipped_row_blocks: int
+    skipped_pre_k_row_blocks: int
+    skipped_post_qk_row_blocks: int
+    computed_row_blocks: int
+    masked_row_blocks: int
+    total_row_blocks: int
+    skip_fraction: float
+    max_error_bound: float
+    mean_error_bound: float
+    row_error_bound: torch.Tensor
+    lse: torch.Tensor
+
+
+@dataclass(frozen=True)
+class CertifiedAttentionOutput:
+    """Output wrapper returned when ``return_stats=True``."""
+
+    output: torch.Tensor
+    stats: CertifiedAttentionStats
+
+
+def _validate_inputs(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor) -> None:
+    if query.dim() != 4 or key.dim() != 4 or value.dim() != 4:
+        raise ValueError("query, key, and value must have shape [batch, seq, heads, dim]")
+    if key.shape != value.shape:
+        raise ValueError("key and value must have the same shape")
+    if query.shape[0] != key.shape[0]:
+        raise ValueError("query and key must have the same batch size")
+    if query.shape[2] != key.shape[2]:
+        raise ValueError("certified_attention currently requires Q/K/V to have the same head count")
+    if query.shape[3] != key.shape[3]:
+        raise ValueError("query and key must have the same head dimension")
+
+
+def _safe_div(num: torch.Tensor, den: torch.Tensor) -> torch.Tensor:
+    return torch.where(den > 0, num / den, torch.zeros_like(num))
+
+
+def _current_output_norm(acc_num: torch.Tensor, acc_den: torch.Tensor) -> torch.Tensor:
+    out = _safe_div(acc_num, acc_den[..., None])
+    return torch.linalg.vector_norm(out, dim=-1)
+
+
+def _skip_from_den_bound(
+    den_bound: torch.Tensor,
+    value_bound: torch.Tensor,
+    acc_num: torch.Tensor,
+    acc_den: torch.Tensor,
+    error_budget: float,
+    predicate: str,
+) -> torch.Tensor:
+    if predicate == "mass":
+        return den_bound <= error_budget * acc_den
+    if predicate == "value_bound":
+        rho = _safe_div(den_bound, acc_den + den_bound)
+        out_norm = _current_output_norm(acc_num, acc_den)
+        return rho * (value_bound + out_norm) <= error_budget
+    raise ValueError(f"unknown skip predicate: {predicate}")
+
+
+def certified_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    causal: bool = True,
+    error_budget: float = 1e-3,
+    block_size: int = 64,
+    summaries: Optional[BlockSummaries] = None,
+    num_summary_outliers: int = 0,
+    skip_predicate: Literal["mass", "value_bound"] = "value_bound",
+    block_order: BlockOrder = "sequential",
+    enable_summary_gate: bool = True,
+    enable_post_qk_gate: bool = True,
+    summary_threshold: float = 0.0,
+    post_qk_threshold: float = 0.0,
+    return_stats: bool = False,
+) -> Union[torch.Tensor, CertifiedAttentionOutput]:
+    """Compute attention with certified K/V block skipping.
+
+    This is a PyTorch reference path for validating the certified-attention
+    math. It streams K/V blocks, maintains online-softmax state, and skips a
+    row/block only when the selected predicate certifies the skipped block is
+    below ``error_budget``.
+
+    Gate 0 uses K/V summaries before full K/V loading. Gate 1 computes QK,
+    then applies a BLASST-style local-max test before loading V/PV work.
+
+    ``error_budget=0`` disables skipping and returns exact tiled attention up to
+    normal floating-point differences.
+    """
+
+    _validate_inputs(query, key, value)
+    if error_budget < 0:
+        raise ValueError("error_budget must be non-negative")
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+
+    batch, seq_q, heads, dim = query.shape
+    seq_k = key.shape[1]
+    scale = 1.0 / math.sqrt(dim)
+    out_dtype = query.dtype
+    device = query.device
+
+    if summaries is None:
+        summaries = build_block_summaries(
+            key,
+            value,
+            block_size=block_size,
+            num_outliers=num_summary_outliers,
+        )
+    elif summaries.block_size != block_size:
+        raise ValueError("summaries.block_size must match block_size")
+    elif summaries.seq_len != seq_k:
+        raise ValueError("summaries.seq_len must match key sequence length")
+
+    q = query.permute(0, 2, 1, 3).contiguous().float()
+    k = key.permute(0, 2, 1, 3).contiguous().float()
+    v = value.permute(0, 2, 1, 3).contiguous().float()
+
+    running_max = torch.full((batch, heads, seq_q), -float("inf"), device=device)
+    acc_den = torch.zeros(batch, heads, seq_q, device=device)
+    acc_num = torch.zeros(batch, heads, seq_q, dim, device=device)
+    skipped_den_bound = torch.zeros(batch, heads, seq_q, device=device)
+
+    query_pos = torch.arange(seq_q, device=device)
+    skipped_row_blocks = 0
+    skipped_pre_k_row_blocks = 0
+    skipped_post_qk_row_blocks = 0
+    computed_row_blocks = 0
+    masked_row_blocks = 0
+    order = resolve_block_order(block_order, q, summaries, scale=scale)
+
+    for block_idx in order:
+        start = block_idx * block_size
+        end = min(start + block_size, seq_k)
+        block_len = int(summaries.block_lengths[block_idx].item())
+        key_pos = torch.arange(start, end, device=device)
+
+        if causal:
+            valid_row = query_pos >= start
+            full_block_allowed = query_pos >= (end - 1)
+        else:
+            valid_row = torch.ones(seq_q, device=device, dtype=torch.bool)
+            full_block_allowed = valid_row
+
+        valid_row_bh = valid_row.view(1, 1, seq_q).expand(batch, heads, seq_q)
+        full_allowed_bh = full_block_allowed.view(1, 1, seq_q).expand(
+            batch, heads, seq_q
+        )
+
+        block_value_bound = summaries.max_value_norm[:, :, block_idx][:, :, None]
+        upper = block_score_upper_bound(q, summaries, block_idx, scale=scale)
+        has_state = torch.isfinite(running_max) & (acc_den > 0)
+        if enable_summary_gate:
+            can_skip = (
+                valid_row_bh
+                & full_allowed_bh
+                & has_state
+                & (upper <= running_max - summary_threshold)
+                & (error_budget > 0)
+            )
+        else:
+            can_skip = torch.zeros_like(valid_row_bh)
+
+        den_bound = torch.zeros_like(acc_den)
+        den_bound[can_skip] = block_len * torch.exp(
+            upper[can_skip] - running_max[can_skip]
+        )
+        skip_pre = can_skip & _skip_from_den_bound(
+            den_bound,
+            block_value_bound,
+            acc_num,
+            acc_den,
+            error_budget,
+            skip_predicate,
+        )
+
+        skipped_den_bound = skipped_den_bound + torch.where(
+            skip_pre, den_bound, torch.zeros_like(den_bound)
+        )
+
+        compute_row = valid_row_bh & ~skip_pre
+        masked_row_blocks += int((~valid_row_bh).sum().item())
+        skipped_pre_k_row_blocks += int(skip_pre.sum().item())
+
+        if not bool(compute_row.any()):
+            continue
+
+        k_tile = k[:, :, start:end, :]
+        scores = torch.einsum("bhsd,bhkd->bhsk", q, k_tile) * scale
+
+        if causal:
+            causal_mask = key_pos.view(1, 1, 1, block_len) <= query_pos.view(
+                1, 1, seq_q, 1
+            )
+            scores = scores.masked_fill(~causal_mask, -float("inf"))
+
+        scores = scores.masked_fill(~compute_row[..., None], -float("inf"))
+
+        tile_max = scores.amax(dim=-1)
+        if enable_post_qk_gate:
+            can_skip_post = (
+                compute_row
+                & has_state
+                & (tile_max <= running_max - post_qk_threshold)
+                & (error_budget > 0)
+            )
+        else:
+            can_skip_post = torch.zeros_like(compute_row)
+        post_den_bound = torch.zeros_like(acc_den)
+        post_den_bound[can_skip_post] = block_len * torch.exp(
+            tile_max[can_skip_post] - running_max[can_skip_post]
+        )
+        skip_post = can_skip_post & _skip_from_den_bound(
+            post_den_bound,
+            block_value_bound,
+            acc_num,
+            acc_den,
+            error_budget,
+            skip_predicate,
+        )
+        skipped_den_bound = skipped_den_bound + torch.where(
+            skip_post,
+            post_den_bound,
+            torch.zeros_like(post_den_bound),
+        )
+        skipped_post_qk_row_blocks += int(skip_post.sum().item())
+
+        compute_row = compute_row & ~skip_post
+        computed_row_blocks += int(compute_row.sum().item())
+        if not bool(compute_row.any()):
+            continue
+
+        scores = scores.masked_fill(~compute_row[..., None], -float("inf"))
+        v_tile = v[:, :, start:end, :]
+        tile_max = scores.amax(dim=-1)
+        tile_valid = torch.isfinite(tile_max)
+        prev_valid = torch.isfinite(running_max)
+        new_valid = prev_valid | tile_valid
+        new_max = torch.maximum(running_max, tile_max)
+        safe_new_max = torch.where(new_valid, new_max, torch.zeros_like(new_max))
+
+        correction = torch.where(
+            prev_valid,
+            torch.exp(running_max - safe_new_max),
+            torch.zeros_like(acc_den),
+        )
+
+        exp_scores = torch.exp(scores - safe_new_max[..., None])
+        exp_scores = torch.where(torch.isfinite(scores), exp_scores, torch.zeros_like(exp_scores))
+
+        acc_num = acc_num * correction[..., None] + torch.einsum(
+            "bhsk,bhkd->bhsd", exp_scores, v_tile
+        )
+        acc_den = acc_den * correction + exp_scores.sum(dim=-1)
+        skipped_den_bound = skipped_den_bound * correction
+        running_max = torch.where(new_valid, new_max, running_max)
+
+    output = _safe_div(acc_num, acc_den[..., None])
+    lse = torch.where(
+        acc_den > 0,
+        running_max + torch.log(acc_den),
+        torch.full_like(acc_den, -float("inf")),
+    )
+
+    max_value_norm = summaries.max_value_norm.amax(dim=-1)
+    max_value_norm = max_value_norm[:, :, None].expand(batch, heads, seq_q)
+    skipped_mass_fraction = _safe_div(skipped_den_bound, acc_den + skipped_den_bound)
+    row_error_bound_bh = 2.0 * max_value_norm * skipped_mass_fraction
+
+    output_bshd = output.permute(0, 2, 1, 3).contiguous().to(out_dtype)
+    row_error_bound = row_error_bound_bh.permute(0, 2, 1).contiguous()
+    lse_bsh = lse.permute(0, 2, 1).contiguous()
+
+    if not return_stats:
+        return output_bshd
+
+    skipped_row_blocks = skipped_pre_k_row_blocks + skipped_post_qk_row_blocks
+    total_row_blocks = batch * heads * seq_q * summaries.num_blocks
+    active_row_blocks = skipped_row_blocks + computed_row_blocks
+    skip_fraction = (
+        skipped_row_blocks / active_row_blocks if active_row_blocks > 0 else 0.0
+    )
+    stats = CertifiedAttentionStats(
+        skipped_row_blocks=skipped_row_blocks,
+        skipped_pre_k_row_blocks=skipped_pre_k_row_blocks,
+        skipped_post_qk_row_blocks=skipped_post_qk_row_blocks,
+        computed_row_blocks=computed_row_blocks,
+        masked_row_blocks=masked_row_blocks,
+        total_row_blocks=total_row_blocks,
+        skip_fraction=float(skip_fraction),
+        max_error_bound=float(row_error_bound.max().item()) if row_error_bound.numel() else 0.0,
+        mean_error_bound=float(row_error_bound.mean().item()) if row_error_bound.numel() else 0.0,
+        row_error_bound=row_error_bound,
+        lse=lse_bsh,
+    )
+    return CertifiedAttentionOutput(output=output_bshd, stats=stats)

--- a/stream_attention/certified/bounds.py
+++ b/stream_attention/certified/bounds.py
@@ -1,0 +1,57 @@
+"""Bound calculations for certified attention."""
+
+import math
+from typing import Optional
+
+import torch
+
+from .summaries import BlockSummaries
+
+
+def block_score_upper_bound(
+    query: torch.Tensor,
+    summaries: BlockSummaries,
+    block_idx: int,
+    *,
+    scale: Optional[float] = None,
+) -> torch.Tensor:
+    """Upper-bound QK scores for one K block.
+
+    Args:
+        query: Tensor with shape ``[batch, heads, seq_q, dim]`` in float.
+        summaries: K/V block summaries.
+        block_idx: Summary block index.
+        scale: Optional attention scale. Defaults to ``1 / sqrt(dim)``.
+
+    Returns:
+        Tensor with shape ``[batch, heads, seq_q]`` where each element bounds
+        every scaled dot-product score between that query row and any key in
+        ``block_idx``.
+    """
+
+    if query.dim() != 4:
+        raise ValueError("query must have shape [batch, heads, seq_q, dim]")
+    if block_idx < 0 or block_idx >= summaries.num_blocks:
+        raise IndexError("block_idx is out of range")
+
+    dim = query.shape[-1]
+    scale = (1.0 / math.sqrt(dim)) if scale is None else scale
+
+    centroid = summaries.centroid[:, :, block_idx, :]
+    radius = summaries.radius[:, :, block_idx]
+    dot_centroid = torch.sum(query * centroid[:, :, None, :], dim=-1)
+    query_norm = torch.linalg.vector_norm(query, dim=-1)
+    residual_bound = (dot_centroid + query_norm * radius[:, :, None]) * scale
+
+    if summaries.outlier_keys is None or summaries.outlier_mask is None:
+        return residual_bound
+
+    outliers = summaries.outlier_keys[:, :, block_idx, :, :]
+    outlier_mask = summaries.outlier_mask[:, :, block_idx, :]
+    outlier_scores = torch.einsum("bhsd,bhod->bhso", query, outliers) * scale
+    outlier_scores = outlier_scores.masked_fill(
+        ~outlier_mask[:, :, None, :],
+        -float("inf"),
+    )
+    outlier_bound = outlier_scores.amax(dim=-1)
+    return torch.maximum(residual_bound, outlier_bound)

--- a/stream_attention/certified/reorder.py
+++ b/stream_attention/certified/reorder.py
@@ -1,0 +1,59 @@
+"""K/V block ordering policies for certified attention."""
+
+from typing import Sequence, Union
+
+import torch
+
+from .bounds import block_score_upper_bound
+from .summaries import BlockSummaries
+
+
+BlockOrder = Union[str, Sequence[int]]
+
+
+def resolve_block_order(
+    order: BlockOrder,
+    query: torch.Tensor,
+    summaries: BlockSummaries,
+    *,
+    scale: float,
+) -> list[int]:
+    """Resolve a block-order policy to concrete block indices.
+
+    Args:
+        order: ``"sequential"``, ``"reverse"``, ``"sink_local"``,
+            ``"summary_desc"``, or an explicit sequence of block ids.
+        query: Query tensor in ``[batch, heads, seq_q, dim]`` layout.
+        summaries: K/V block summaries.
+        scale: Attention score scale.
+    """
+
+    num_blocks = summaries.num_blocks
+    if isinstance(order, str):
+        if order == "sequential":
+            return list(range(num_blocks))
+        if order == "reverse":
+            return list(reversed(range(num_blocks)))
+        if order == "sink_local":
+            if num_blocks == 0:
+                return []
+            return [0] + list(reversed(range(1, num_blocks)))
+        if order == "summary_desc":
+            scores = []
+            for block_idx in range(num_blocks):
+                upper = block_score_upper_bound(
+                    query,
+                    summaries,
+                    block_idx,
+                    scale=scale,
+                )
+                scores.append(float(upper.max().item()))
+            return sorted(range(num_blocks), key=lambda idx: scores[idx], reverse=True)
+        raise ValueError(f"unknown block order: {order}")
+
+    resolved = [int(idx) for idx in order]
+    expected = set(range(num_blocks))
+    if set(resolved) != expected or len(resolved) != num_blocks:
+        raise ValueError("explicit block order must be a permutation of all block ids")
+    return resolved
+

--- a/stream_attention/certified/summaries.py
+++ b/stream_attention/certified/summaries.py
@@ -1,0 +1,153 @@
+"""K/V block summaries for certified attention."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass(frozen=True)
+class BlockSummaries:
+    """Centroid/radius summaries for K/V blocks.
+
+    Shapes use ``[batch, heads, blocks, ...]`` because the certified attention
+    prototype internally works in batch/head-major layout.
+    """
+
+    centroid: torch.Tensor
+    radius: torch.Tensor
+    max_key_norm: torch.Tensor
+    max_value_norm: torch.Tensor
+    block_lengths: torch.Tensor
+    block_size: int
+    seq_len: int
+    outlier_keys: Optional[torch.Tensor] = None
+    outlier_mask: Optional[torch.Tensor] = None
+
+    @property
+    def num_blocks(self) -> int:
+        return int(self.centroid.shape[2])
+
+
+def _validate_kv(key: torch.Tensor, value: Optional[torch.Tensor]) -> None:
+    if key.dim() != 4:
+        raise ValueError("key must have shape [batch, seq, heads, dim]")
+    if value is not None and value.shape != key.shape:
+        raise ValueError("value must have the same shape as key")
+
+
+def build_block_summaries(
+    key: torch.Tensor,
+    value: Optional[torch.Tensor] = None,
+    *,
+    block_size: int = 64,
+    num_outliers: int = 0,
+) -> BlockSummaries:
+    """Build centroid/radius summaries for K/V blocks.
+
+    Args:
+        key: Tensor with shape ``[batch, seq_k, heads, dim]``.
+        value: Optional tensor with the same shape as ``key``. When omitted,
+            ``max_value_norm`` is filled with zeros.
+        block_size: Number of K/V tokens represented by one summary block.
+        num_outliers: Number of farthest-from-centroid keys to split out from
+            each residual ball. ``0`` gives plain centroid/radius summaries.
+
+    Returns:
+        ``BlockSummaries`` in batch/head-major layout.
+    """
+
+    _validate_kv(key, value)
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+    if num_outliers < 0:
+        raise ValueError("num_outliers must be non-negative")
+
+    batch, seq_len, heads, dim = key.shape
+    num_blocks = (seq_len + block_size - 1) // block_size
+    device = key.device
+
+    key_bh = key.permute(0, 2, 1, 3).contiguous().float()
+    value_bh = None if value is None else value.permute(0, 2, 1, 3).contiguous().float()
+
+    centroid = torch.empty(batch, heads, num_blocks, dim, device=device, dtype=torch.float32)
+    radius = torch.empty(batch, heads, num_blocks, device=device, dtype=torch.float32)
+    max_key_norm = torch.empty(batch, heads, num_blocks, device=device, dtype=torch.float32)
+    max_value_norm = torch.empty(batch, heads, num_blocks, device=device, dtype=torch.float32)
+    block_lengths = torch.empty(num_blocks, device=device, dtype=torch.long)
+    outlier_keys = None
+    outlier_mask = None
+    if num_outliers > 0:
+        outlier_keys = torch.zeros(
+            batch,
+            heads,
+            num_blocks,
+            num_outliers,
+            dim,
+            device=device,
+            dtype=torch.float32,
+        )
+        outlier_mask = torch.zeros(
+            batch,
+            heads,
+            num_blocks,
+            num_outliers,
+            device=device,
+            dtype=torch.bool,
+        )
+
+    for block_idx in range(num_blocks):
+        start = block_idx * block_size
+        end = min(start + block_size, seq_len)
+        block = key_bh[:, :, start:end, :]
+        raw_center = block.mean(dim=2)
+        raw_centered = block - raw_center[:, :, None, :]
+
+        if num_outliers > 0:
+            selected = min(num_outliers, end - start)
+            dist = torch.linalg.vector_norm(raw_centered, dim=-1)
+            top_idx = torch.topk(dist, k=selected, dim=-1).indices
+            gathered = torch.gather(
+                block,
+                2,
+                top_idx[:, :, :, None].expand(batch, heads, selected, dim),
+            )
+            outlier_keys[:, :, block_idx, :selected, :] = gathered
+            outlier_mask[:, :, block_idx, :selected] = True
+
+            keep = torch.ones(batch, heads, end - start, device=device, dtype=torch.bool)
+            keep.scatter_(2, top_idx, False)
+            keep_f = keep.to(torch.float32)
+            residual_count = keep_f.sum(dim=2).clamp_min(1.0)
+            center = (block * keep_f[:, :, :, None]).sum(dim=2) / residual_count[:, :, None]
+            centered = block - center[:, :, None, :]
+            residual_dist = torch.linalg.vector_norm(centered, dim=-1)
+            residual_dist = residual_dist.masked_fill(~keep, 0.0)
+        else:
+            center = raw_center
+            residual_dist = torch.linalg.vector_norm(raw_centered, dim=-1)
+
+        centroid[:, :, block_idx, :] = center
+        radius[:, :, block_idx] = residual_dist.amax(dim=-1)
+        max_key_norm[:, :, block_idx] = torch.linalg.vector_norm(block, dim=-1).amax(dim=-1)
+        block_lengths[block_idx] = end - start
+
+        if value_bh is None:
+            max_value_norm[:, :, block_idx] = 0.0
+        else:
+            value_block = value_bh[:, :, start:end, :]
+            max_value_norm[:, :, block_idx] = torch.linalg.vector_norm(
+                value_block, dim=-1
+            ).amax(dim=-1)
+
+    return BlockSummaries(
+        centroid=centroid,
+        radius=radius,
+        max_key_norm=max_key_norm,
+        max_value_norm=max_value_norm,
+        block_lengths=block_lengths,
+        block_size=block_size,
+        seq_len=seq_len,
+        outlier_keys=outlier_keys,
+        outlier_mask=outlier_mask,
+    )

--- a/stream_attention/core/fused_online_attention.py
+++ b/stream_attention/core/fused_online_attention.py
@@ -921,6 +921,10 @@ class FusedOnlineAttention(nn.Module):
                 mask_supported = attention_mask.shape[0] == batch_size and attention_mask.shape[-1] == seq_len_k
             else:
                 mask_supported = False
+            # Until Triton kernel mask parity is validated on pre-SM80 GPUs (e.g., T4),
+            # fall back to PyTorch SDPA when a mask is supplied on those architectures.
+            if mask_supported and self.sm and self.sm < 80:
+                mask_supported = False
 
         use_triton = (
             TRITON_AVAILABLE

--- a/stream_attention/kernels/__init__.py
+++ b/stream_attention/kernels/__init__.py
@@ -1,0 +1,6 @@
+"""Experimental Triton/CUDA kernels.
+
+Kernel modules in this package are not wired into the public StreamAttention
+router until they have GPU CI coverage.
+"""
+

--- a/stream_attention/kernels/certified_fwd_triton.py
+++ b/stream_attention/kernels/certified_fwd_triton.py
@@ -1,0 +1,291 @@
+"""Experimental Triton forward kernel for two-gate certified attention.
+
+This module is intentionally narrow:
+- contiguous Q/K/V tensors in [batch, seq, heads, dim]
+- same Q/K/V head count
+- no dropout, masks, ALiBi, or varlen
+- optional causal masking
+- centroid/radius summaries, no outlier summaries
+
+It exists to make the PyTorch reference path kernel-shaped. Keep the reference
+implementation in ``stream_attention.certified`` as the oracle.
+"""
+
+import math
+from typing import Optional, Tuple
+
+import torch
+
+from stream_attention.certified.summaries import BlockSummaries, build_block_summaries
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except Exception:  # pragma: no cover - environment dependent
+    TRITON_AVAILABLE = False
+
+
+if TRITON_AVAILABLE:
+
+    @triton.jit
+    def _certified_fwd_kernel(
+        Q,
+        K,
+        V,
+        Centroid,
+        Radius,
+        MaxVNorm,
+        Out,
+        RawStats,
+        B: tl.constexpr,
+        M: tl.constexpr,
+        N: tl.constexpr,
+        H: tl.constexpr,
+        D: tl.constexpr,
+        NUM_BLOCKS: tl.constexpr,
+        TILE_M: tl.constexpr,
+        TILE_N: tl.constexpr,
+        SCALE: tl.constexpr,
+        ERROR_BUDGET: tl.constexpr,
+        IS_CAUSAL: tl.constexpr,
+        VALUE_BOUND: tl.constexpr,
+        HAS_STATS: tl.constexpr,
+    ):
+        q_block = tl.program_id(0)
+        off_b = tl.program_id(1)
+        off_h = tl.program_id(2)
+
+        offs_m = q_block * TILE_M + tl.arange(0, TILE_M)
+        offs_d = tl.arange(0, D)
+        row_mask = offs_m < M
+
+        q_ptrs = (
+            Q
+            + off_b * M * H * D
+            + offs_m[:, None] * H * D
+            + off_h * D
+            + offs_d[None, :]
+        )
+        q = tl.load(q_ptrs, mask=row_mask[:, None], other=0.0).to(tl.float32)
+        q_norm = tl.sqrt(tl.sum(q * q, axis=1))
+
+        running_max = tl.full([TILE_M], -float("inf"), dtype=tl.float32)
+        acc_den = tl.zeros([TILE_M], dtype=tl.float32)
+        acc_num = tl.zeros([TILE_M, D], dtype=tl.float32)
+
+        pre_count = tl.zeros([], dtype=tl.int32)
+        post_count = tl.zeros([], dtype=tl.int32)
+        compute_count = tl.zeros([], dtype=tl.int32)
+
+        for block_idx in range(0, NUM_BLOCKS):
+            start_n = block_idx * TILE_N
+            offs_n = start_n + tl.arange(0, TILE_N)
+            block_len_i: tl.constexpr = min(TILE_N, N - start_n)
+            col_mask = tl.arange(0, TILE_N) < block_len_i
+            block_len = tl.full([], block_len_i, dtype=tl.float32)
+
+            if IS_CAUSAL:
+                valid_row = row_mask & (offs_m >= start_n)
+                full_allowed = row_mask & (offs_m >= (start_n + block_len_i - 1))
+            else:
+                valid_row = row_mask
+                full_allowed = row_mask
+
+            c_ptrs = (
+                Centroid
+                + off_b * H * NUM_BLOCKS * D
+                + off_h * NUM_BLOCKS * D
+                + block_idx * D
+                + offs_d
+            )
+            centroid = tl.load(c_ptrs).to(tl.float32)
+            radius = tl.load(Radius + off_b * H * NUM_BLOCKS + off_h * NUM_BLOCKS + block_idx).to(tl.float32)
+            max_v_norm = tl.load(MaxVNorm + off_b * H * NUM_BLOCKS + off_h * NUM_BLOCKS + block_idx).to(tl.float32)
+
+            upper = (tl.sum(q * centroid[None, :], axis=1) + q_norm * radius) * SCALE
+            has_state = acc_den > 0.0
+            can_skip_pre = (
+                valid_row
+                & full_allowed
+                & has_state
+                & (upper <= running_max)
+                & (ERROR_BUDGET > 0.0)
+            )
+            den_bound = block_len * tl.exp(upper - running_max)
+            den_bound = tl.where(can_skip_pre, den_bound, 0.0)
+
+            current_out = acc_num / tl.maximum(acc_den, 1.0)[:, None]
+            out_norm = tl.sqrt(tl.sum(current_out * current_out, axis=1))
+            if VALUE_BOUND:
+                rho = den_bound / (acc_den + den_bound)
+                skip_pre = can_skip_pre & (rho * (max_v_norm + out_norm) <= ERROR_BUDGET)
+            else:
+                skip_pre = can_skip_pre & (den_bound <= ERROR_BUDGET * acc_den)
+
+            pre_count += tl.sum(skip_pre.to(tl.int32), axis=0)
+            k_ptrs = (
+                K
+                + off_b * N * H * D
+                + offs_n[:, None] * H * D
+                + off_h * D
+                + offs_d[None, :]
+            )
+            k_tile = tl.load(k_ptrs, mask=col_mask[:, None], other=0.0).to(tl.float32)
+            qk = tl.dot(q, tl.trans(k_tile)) * SCALE
+            qk = tl.where(col_mask[None, :], qk, -float("inf"))
+
+            if IS_CAUSAL:
+                qk = tl.where(offs_m[:, None] >= offs_n[None, :], qk, -float("inf"))
+            qk = tl.where((valid_row & ~skip_pre)[:, None], qk, -float("inf"))
+
+            tile_max = tl.max(qk, axis=1)
+            can_skip_post = (
+                (valid_row & ~skip_pre)
+                & has_state
+                & (tile_max <= running_max)
+                & (ERROR_BUDGET > 0.0)
+            )
+            post_den_bound = block_len * tl.exp(tile_max - running_max)
+            post_den_bound = tl.where(can_skip_post, post_den_bound, 0.0)
+            if VALUE_BOUND:
+                rho_post = post_den_bound / (acc_den + post_den_bound)
+                skip_post = can_skip_post & (
+                    rho_post * (max_v_norm + out_norm) <= ERROR_BUDGET
+                )
+            else:
+                skip_post = can_skip_post & (post_den_bound <= ERROR_BUDGET * acc_den)
+
+            post_count += tl.sum(skip_post.to(tl.int32), axis=0)
+            compute_row = valid_row & ~skip_pre & ~skip_post
+            compute_count += tl.sum(compute_row.to(tl.int32), axis=0)
+
+            qk = tl.where(compute_row[:, None], qk, -float("inf"))
+            tile_max = tl.max(qk, axis=1)
+            tile_valid = tile_max > -float("inf")
+            prev_valid = acc_den > 0.0
+            new_valid = prev_valid | tile_valid
+            new_max = tl.maximum(running_max, tile_max)
+            safe_new_max = tl.where(new_valid, new_max, 0.0)
+            correction = tl.where(
+                prev_valid,
+                tl.exp(running_max - safe_new_max),
+                0.0,
+            )
+
+            p = tl.exp(qk - safe_new_max[:, None])
+            p = tl.where(qk > -float("inf"), p, 0.0)
+
+            v_ptrs = (
+                V
+                + off_b * N * H * D
+                + offs_n[:, None] * H * D
+                + off_h * D
+                + offs_d[None, :]
+            )
+            v_tile = tl.load(v_ptrs, mask=col_mask[:, None], other=0.0).to(tl.float32)
+
+            acc_num = acc_num * correction[:, None] + tl.dot(p, v_tile)
+            acc_den = acc_den * correction + tl.sum(p, axis=1)
+            running_max = tl.where(new_valid, new_max, running_max)
+
+        out = acc_num / acc_den[:, None]
+        out = tl.where(acc_den[:, None] > 0.0, out, 0.0)
+        out_ptrs = (
+            Out
+            + off_b * M * H * D
+            + offs_m[:, None] * H * D
+            + off_h * D
+            + offs_d[None, :]
+        )
+        tl.store(out_ptrs, out, mask=row_mask[:, None])
+
+        if HAS_STATS:
+            stats_base = ((off_b * H + off_h) * ((M + TILE_M - 1) // TILE_M) + q_block) * 3
+            tl.store(RawStats + stats_base + 0, pre_count)
+            tl.store(RawStats + stats_base + 1, post_count)
+            tl.store(RawStats + stats_base + 2, compute_count)
+
+
+def certified_attention_triton_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    causal: bool = True,
+    error_budget: float = 1e-3,
+    block_size: int = 64,
+    tile_size_q: int = 64,
+    summaries: Optional[BlockSummaries] = None,
+    skip_predicate: str = "value_bound",
+    return_raw_stats: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Run the experimental Triton certified forward kernel.
+
+    Returns ``(output, raw_stats)``. ``raw_stats`` has shape
+    ``[batch, heads, q_blocks, 3]`` with pre-skip, post-skip, and compute
+    row-block counts when requested.
+    """
+
+    if not TRITON_AVAILABLE:
+        raise RuntimeError("Triton is not available")
+    if not (query.is_cuda and key.is_cuda and value.is_cuda):
+        raise RuntimeError("certified_attention_triton_forward requires CUDA tensors")
+    if query.dim() != 4 or key.dim() != 4 or value.dim() != 4:
+        raise ValueError("query, key, and value must be [batch, seq, heads, dim]")
+    if key.shape != value.shape:
+        raise ValueError("key and value must have the same shape")
+    if query.shape[0] != key.shape[0] or query.shape[2:] != key.shape[2:]:
+        raise ValueError("restricted Triton path requires matching batch, heads, and dim")
+    if skip_predicate not in {"mass", "value_bound"}:
+        raise ValueError("skip_predicate must be 'mass' or 'value_bound'")
+
+    query = query.contiguous()
+    key = key.contiguous()
+    value = value.contiguous()
+    batch, seq_q, heads, dim = query.shape
+    seq_k = key.shape[1]
+
+    if summaries is None:
+        summaries = build_block_summaries(key, value, block_size=block_size)
+    if summaries.outlier_keys is not None:
+        raise ValueError("experimental Triton path does not support outlier summaries yet")
+    if summaries.block_size != block_size or summaries.seq_len != seq_k:
+        raise ValueError("summary shape does not match key/block_size")
+
+    output = torch.empty_like(query)
+    q_blocks = triton.cdiv(seq_q, tile_size_q)
+    raw_stats = (
+        torch.empty(batch, heads, q_blocks, 3, device=query.device, dtype=torch.int32)
+        if return_raw_stats
+        else torch.empty(1, device=query.device, dtype=torch.int32)
+    )
+
+    grid = (q_blocks, batch, heads)
+    _certified_fwd_kernel[grid](
+        query,
+        key,
+        value,
+        summaries.centroid.contiguous(),
+        summaries.radius.contiguous(),
+        summaries.max_value_norm.contiguous(),
+        output,
+        raw_stats,
+        B=batch,
+        M=seq_q,
+        N=seq_k,
+        H=heads,
+        D=dim,
+        NUM_BLOCKS=triton.cdiv(seq_k, block_size),
+        TILE_M=tile_size_q,
+        TILE_N=block_size,
+        SCALE=1.0 / math.sqrt(dim),
+        ERROR_BUDGET=float(error_budget),
+        IS_CAUSAL=bool(causal),
+        VALUE_BOUND=skip_predicate == "value_bound",
+        HAS_STATS=return_raw_stats,
+        num_warps=4,
+        num_stages=3,
+    )
+    return output, raw_stats if return_raw_stats else None

--- a/stream_attention/kernels/gate1_fwd_triton.py
+++ b/stream_attention/kernels/gate1_fwd_triton.py
@@ -1,0 +1,274 @@
+"""Gate-1 post-QK sparse attention forward kernel.
+
+Gate 1 is the first production-oriented sparse step:
+compute QK for each K block, use the block-local max with online-softmax state,
+and skip V load/PV when the block is negligible for the whole query tile.
+
+This module deliberately does not use K summaries. Gate 0 summary routing should
+be implemented as a scheduler/worklist path, not as the first hot-kernel bet.
+
+Modal A10G smoke currently shows correct skip telemetry but little latency
+change, which likely means Triton's dynamic branch is not enough by itself for
+production speed. Keep this as a correctness/smoke kernel while developing a
+scheduler/worklist or CUDA/CuTe implementation for the hot path.
+"""
+
+import math
+from typing import Optional, Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except Exception:  # pragma: no cover - environment dependent
+    TRITON_AVAILABLE = False
+
+
+def build_value_norm_bounds(value: torch.Tensor, *, block_size: int) -> torch.Tensor:
+    """Return max ||V|| per [batch, head, K-block]."""
+
+    if value.dim() != 4:
+        raise ValueError("value must have shape [batch, seq, heads, dim]")
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+
+    batch, seq_len, heads, _ = value.shape
+    num_blocks = (seq_len + block_size - 1) // block_size
+    value_bh = value.permute(0, 2, 1, 3).contiguous().float()
+    bounds = torch.empty(batch, heads, num_blocks, device=value.device, dtype=torch.float32)
+
+    for block_idx in range(num_blocks):
+        start = block_idx * block_size
+        end = min(start + block_size, seq_len)
+        bounds[:, :, block_idx] = torch.linalg.vector_norm(
+            value_bh[:, :, start:end, :],
+            dim=-1,
+        ).amax(dim=-1)
+    return bounds
+
+
+if TRITON_AVAILABLE:
+
+    @triton.jit
+    def _gate1_fwd_kernel(
+        Q,
+        K,
+        V,
+        MaxVNorm,
+        Out,
+        RawStats,
+        M: tl.constexpr,
+        N: tl.constexpr,
+        H: tl.constexpr,
+        D: tl.constexpr,
+        NUM_BLOCKS: tl.constexpr,
+        TILE_M: tl.constexpr,
+        TILE_N: tl.constexpr,
+        SCALE: tl.constexpr,
+        ERROR_BUDGET: tl.constexpr,
+        POST_QK_THRESHOLD: tl.constexpr,
+        IS_CAUSAL: tl.constexpr,
+        VALUE_BOUND: tl.constexpr,
+        HAS_STATS: tl.constexpr,
+    ):
+        q_block = tl.program_id(0)
+        off_b = tl.program_id(1)
+        off_h = tl.program_id(2)
+
+        offs_m = q_block * TILE_M + tl.arange(0, TILE_M)
+        offs_d = tl.arange(0, D)
+        row_mask = offs_m < M
+
+        q_ptrs = (
+            Q
+            + off_b * M * H * D
+            + offs_m[:, None] * H * D
+            + off_h * D
+            + offs_d[None, :]
+        )
+        q = tl.load(q_ptrs, mask=row_mask[:, None], other=0.0).to(tl.float32)
+
+        running_max = tl.full([TILE_M], -float("inf"), dtype=tl.float32)
+        acc_den = tl.zeros([TILE_M], dtype=tl.float32)
+        acc_num = tl.zeros([TILE_M, D], dtype=tl.float32)
+
+        post_count = tl.zeros([], dtype=tl.int32)
+        compute_count = tl.zeros([], dtype=tl.int32)
+
+        for block_idx in range(0, NUM_BLOCKS):
+            start_n = block_idx * TILE_N
+            offs_n = start_n + tl.arange(0, TILE_N)
+            block_len_i: tl.constexpr = min(TILE_N, N - start_n)
+            col_mask = tl.arange(0, TILE_N) < block_len_i
+            block_len = tl.full([], block_len_i, dtype=tl.float32)
+
+            if IS_CAUSAL:
+                valid_row = row_mask & (offs_m >= start_n)
+            else:
+                valid_row = row_mask
+
+            k_ptrs = (
+                K
+                + off_b * N * H * D
+                + offs_n[:, None] * H * D
+                + off_h * D
+                + offs_d[None, :]
+            )
+            k_tile = tl.load(k_ptrs, mask=col_mask[:, None], other=0.0).to(tl.float32)
+            qk = tl.dot(q, tl.trans(k_tile)) * SCALE
+            qk = tl.where(col_mask[None, :], qk, -float("inf"))
+            if IS_CAUSAL:
+                qk = tl.where(offs_m[:, None] >= offs_n[None, :], qk, -float("inf"))
+            qk = tl.where(valid_row[:, None], qk, -float("inf"))
+
+            tile_max = tl.max(qk, axis=1)
+            has_state = acc_den > 0.0
+            can_skip = (
+                valid_row
+                & has_state
+                & (tile_max <= running_max - POST_QK_THRESHOLD)
+                & (ERROR_BUDGET > 0.0)
+            )
+
+            den_bound = block_len * tl.exp(tile_max - running_max)
+            den_bound = tl.where(can_skip, den_bound, 0.0)
+            if VALUE_BOUND:
+                max_v_norm = tl.load(
+                    MaxVNorm + off_b * H * NUM_BLOCKS + off_h * NUM_BLOCKS + block_idx
+                ).to(tl.float32)
+                current_out = acc_num / tl.maximum(acc_den, 1.0)[:, None]
+                out_norm = tl.sqrt(tl.sum(current_out * current_out, axis=1))
+                rho = den_bound / (acc_den + den_bound)
+                skip_row = can_skip & (rho * (max_v_norm + out_norm) <= ERROR_BUDGET)
+            else:
+                skip_row = can_skip & (den_bound <= ERROR_BUDGET * acc_den)
+
+            compute_row = valid_row & ~skip_row
+            post_count += tl.sum(skip_row.to(tl.int32), axis=0)
+            compute_count += tl.sum(compute_row.to(tl.int32), axis=0)
+            cta_needs_pv = tl.sum(compute_row.to(tl.int32), axis=0) > 0
+
+            if cta_needs_pv:
+                qk = tl.where(compute_row[:, None], qk, -float("inf"))
+                tile_max = tl.max(qk, axis=1)
+                tile_valid = tile_max > -float("inf")
+                prev_valid = acc_den > 0.0
+                new_valid = prev_valid | tile_valid
+                new_max = tl.maximum(running_max, tile_max)
+                safe_new_max = tl.where(new_valid, new_max, 0.0)
+                correction = tl.where(
+                    prev_valid,
+                    tl.exp(running_max - safe_new_max),
+                    0.0,
+                )
+                p = tl.exp(qk - safe_new_max[:, None])
+                p = tl.where(qk > -float("inf"), p, 0.0)
+
+                v_ptrs = (
+                    V
+                    + off_b * N * H * D
+                    + offs_n[:, None] * H * D
+                    + off_h * D
+                    + offs_d[None, :]
+                )
+                v_tile = tl.load(v_ptrs, mask=col_mask[:, None], other=0.0).to(tl.float32)
+                acc_num = acc_num * correction[:, None] + tl.dot(p, v_tile)
+                acc_den = acc_den * correction + tl.sum(p, axis=1)
+                running_max = tl.where(new_valid, new_max, running_max)
+
+        out = acc_num / acc_den[:, None]
+        out = tl.where(acc_den[:, None] > 0.0, out, 0.0)
+        out_ptrs = (
+            Out
+            + off_b * M * H * D
+            + offs_m[:, None] * H * D
+            + off_h * D
+            + offs_d[None, :]
+        )
+        tl.store(out_ptrs, out, mask=row_mask[:, None])
+
+        if HAS_STATS:
+            stats_base = ((off_b * H + off_h) * ((M + TILE_M - 1) // TILE_M) + q_block) * 2
+            tl.store(RawStats + stats_base + 0, post_count)
+            tl.store(RawStats + stats_base + 1, compute_count)
+
+
+def gate1_attention_triton_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    causal: bool = True,
+    error_budget: float = 1e-3,
+    block_size: int = 64,
+    tile_size_q: int = 64,
+    value_norm_bounds: Optional[torch.Tensor] = None,
+    skip_predicate: str = "value_bound",
+    post_qk_threshold: float = 0.0,
+    return_raw_stats: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Run Gate-1 post-QK skip forward attention.
+
+    Returns ``(output, raw_stats)``. ``raw_stats`` has shape
+    ``[batch, heads, q_blocks, 2]`` with post-skip and compute row-block counts.
+    """
+
+    if not TRITON_AVAILABLE:
+        raise RuntimeError("Triton is not available")
+    if not (query.is_cuda and key.is_cuda and value.is_cuda):
+        raise RuntimeError("gate1_attention_triton_forward requires CUDA tensors")
+    if query.dim() != 4 or key.dim() != 4 or value.dim() != 4:
+        raise ValueError("query, key, and value must be [batch, seq, heads, dim]")
+    if key.shape != value.shape:
+        raise ValueError("key and value must have the same shape")
+    if query.shape[0] != key.shape[0] or query.shape[2:] != key.shape[2:]:
+        raise ValueError("restricted Gate-1 path requires matching batch, heads, and dim")
+    if skip_predicate not in {"mass", "value_bound"}:
+        raise ValueError("skip_predicate must be 'mass' or 'value_bound'")
+
+    query = query.contiguous()
+    key = key.contiguous()
+    value = value.contiguous()
+    batch, seq_q, heads, dim = query.shape
+    seq_k = key.shape[1]
+
+    if value_norm_bounds is None:
+        value_norm_bounds = build_value_norm_bounds(value, block_size=block_size)
+    value_norm_bounds = value_norm_bounds.contiguous()
+
+    output = torch.empty_like(query)
+    q_blocks = triton.cdiv(seq_q, tile_size_q)
+    raw_stats = (
+        torch.empty(batch, heads, q_blocks, 2, device=query.device, dtype=torch.int32)
+        if return_raw_stats
+        else torch.empty(1, device=query.device, dtype=torch.int32)
+    )
+
+    grid = (q_blocks, batch, heads)
+    _gate1_fwd_kernel[grid](
+        query,
+        key,
+        value,
+        value_norm_bounds,
+        output,
+        raw_stats,
+        M=seq_q,
+        N=seq_k,
+        H=heads,
+        D=dim,
+        NUM_BLOCKS=triton.cdiv(seq_k, block_size),
+        TILE_M=tile_size_q,
+        TILE_N=block_size,
+        SCALE=1.0 / math.sqrt(dim),
+        ERROR_BUDGET=float(error_budget),
+        POST_QK_THRESHOLD=float(post_qk_threshold),
+        IS_CAUSAL=bool(causal),
+        VALUE_BOUND=skip_predicate == "value_bound",
+        HAS_STATS=return_raw_stats,
+        num_warps=4,
+        num_stages=3,
+    )
+    return output, raw_stats if return_raw_stats else None

--- a/tests/test_certified_attention.py
+++ b/tests/test_certified_attention.py
@@ -1,0 +1,152 @@
+import math
+
+import torch
+import torch.nn.functional as F
+
+from stream_attention.certified import build_block_summaries, certified_attention
+from stream_attention.certified.bounds import block_score_upper_bound
+
+
+def _sdpa_reference(q, k, v, *, causal):
+    q_bh = q.permute(0, 2, 1, 3).contiguous()
+    k_bh = k.permute(0, 2, 1, 3).contiguous()
+    v_bh = v.permute(0, 2, 1, 3).contiguous()
+    out = F.scaled_dot_product_attention(
+        q_bh,
+        k_bh,
+        v_bh,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=causal,
+    )
+    return out.permute(0, 2, 1, 3).contiguous()
+
+
+def test_block_score_upper_bound_contains_all_scores():
+    torch.manual_seed(0)
+    q = torch.randn(2, 7, 3, 8)
+    k = torch.randn(2, 11, 3, 8)
+    summaries = build_block_summaries(k, block_size=4)
+
+    q_bh = q.permute(0, 2, 1, 3).contiguous().float()
+    k_bh = k.permute(0, 2, 1, 3).contiguous().float()
+    scale = 1.0 / math.sqrt(q.shape[-1])
+
+    for block_idx in range(summaries.num_blocks):
+        start = block_idx * summaries.block_size
+        end = min(start + summaries.block_size, k.shape[1])
+        upper = block_score_upper_bound(q_bh, summaries, block_idx, scale=scale)
+        scores = torch.einsum("bhsd,bhkd->bhsk", q_bh, k_bh[:, :, start:end, :]) * scale
+        assert torch.all(scores <= upper[..., None] + 1e-5)
+
+
+def test_outlier_split_bound_contains_all_scores():
+    torch.manual_seed(4)
+    q = torch.randn(1, 5, 2, 8)
+    k = torch.randn(1, 9, 2, 8)
+    k[:, 3, :, 0] = 20.0
+    summaries = build_block_summaries(k, block_size=5, num_outliers=1)
+
+    q_bh = q.permute(0, 2, 1, 3).contiguous().float()
+    k_bh = k.permute(0, 2, 1, 3).contiguous().float()
+    scale = 1.0 / math.sqrt(q.shape[-1])
+
+    for block_idx in range(summaries.num_blocks):
+        start = block_idx * summaries.block_size
+        end = min(start + summaries.block_size, k.shape[1])
+        upper = block_score_upper_bound(q_bh, summaries, block_idx, scale=scale)
+        scores = torch.einsum("bhsd,bhkd->bhsk", q_bh, k_bh[:, :, start:end, :]) * scale
+        assert torch.all(scores <= upper[..., None] + 1e-5)
+
+
+def test_certified_attention_exact_when_budget_zero_noncausal():
+    torch.manual_seed(1)
+    q = torch.randn(2, 9, 2, 16)
+    k = torch.randn(2, 13, 2, 16)
+    v = torch.randn(2, 13, 2, 16)
+
+    out = certified_attention(
+        q,
+        k,
+        v,
+        causal=False,
+        error_budget=0.0,
+        block_size=4,
+        block_order="reverse",
+    )
+    ref = _sdpa_reference(q, k, v, causal=False)
+    torch.testing.assert_close(out, ref, rtol=2e-5, atol=2e-5)
+
+
+def test_certified_attention_exact_when_budget_zero_causal():
+    torch.manual_seed(2)
+    q = torch.randn(1, 12, 2, 16)
+    k = torch.randn(1, 12, 2, 16)
+    v = torch.randn(1, 12, 2, 16)
+
+    out = certified_attention(
+        q,
+        k,
+        v,
+        causal=True,
+        error_budget=0.0,
+        block_size=4,
+    )
+    ref = _sdpa_reference(q, k, v, causal=True)
+    torch.testing.assert_close(out, ref, rtol=2e-5, atol=2e-5)
+
+
+def test_certified_attention_skips_low_mass_blocks_with_bound():
+    q = torch.zeros(1, 4, 1, 4)
+    k = torch.zeros(1, 8, 1, 4)
+    v = torch.randn(1, 8, 1, 4, generator=torch.Generator().manual_seed(3))
+
+    q[:, :, :, 0] = 8.0
+    k[:, :4, :, 0] = 8.0
+    k[:, 4:, :, 0] = -8.0
+
+    result = certified_attention(
+        q,
+        k,
+        v,
+        causal=False,
+        error_budget=1e-3,
+        block_size=4,
+        return_stats=True,
+    )
+    ref = _sdpa_reference(q, k, v, causal=False)
+    err = torch.linalg.vector_norm(result.output - ref, dim=-1)
+
+    assert result.stats.skipped_row_blocks > 0
+    assert result.stats.skipped_pre_k_row_blocks > 0
+    assert result.stats.skip_fraction > 0.0
+    assert torch.all(err <= result.stats.row_error_bound + 1e-5)
+    assert err.max().item() < 1e-4
+
+
+def test_certified_attention_post_qk_gate_skips_when_summary_gate_disabled():
+    q = torch.zeros(1, 4, 1, 4)
+    k = torch.zeros(1, 8, 1, 4)
+    v = torch.randn(1, 8, 1, 4, generator=torch.Generator().manual_seed(5))
+
+    q[:, :, :, 0] = 8.0
+    k[:, :4, :, 0] = 8.0
+    k[:, 4:, :, 0] = -8.0
+
+    result = certified_attention(
+        q,
+        k,
+        v,
+        causal=False,
+        error_budget=1e-3,
+        block_size=4,
+        enable_summary_gate=False,
+        enable_post_qk_gate=True,
+        return_stats=True,
+    )
+    ref = _sdpa_reference(q, k, v, causal=False)
+    err = torch.linalg.vector_norm(result.output - ref, dim=-1)
+
+    assert result.stats.skipped_pre_k_row_blocks == 0
+    assert result.stats.skipped_post_qk_row_blocks > 0
+    assert torch.all(err <= result.stats.row_error_bound + 1e-5)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a certified attention path that skips K/V blocks with provable error bounds, plus experimental Triton forward kernels (certified and Gate‑1) and smoke/benchmark tooling. Also adds a safe fallback for masked attention on pre‑SM80 GPUs.

- New Features
  - Introduce `stream_attention.certified`: `certified_attention`, `build_block_summaries`, outlier-aware summaries, skip predicates (`mass`, `value_bound`), block orders, and per-row error/skip stats.
  - Add experimental Triton kernels: `stream_attention.kernels.certified_fwd_triton` (Gate 0 + Gate 1) and `stream_attention.kernels.gate1_fwd_triton` (post‑QK), with Modal smoke tests and a probe benchmark.
  - Export new APIs in `stream_attention/__init__.py` and add tests validating exactness at `error_budget=0` and tightness of score/error bounds.

- Bug Fixes
  - On SM < 80, fall back to PyTorch SDPA when a mask is supplied to avoid precision issues; update unit test to apply an explicit causal bias instead of `is_causal=True`.

<sup>Written for commit bf0ea03adc3b04624555d197bc874b3b262c59cc. Summary will update on new commits. <a href="https://cubic.dev/pr/MagellaX/StreamAttn/pull/36?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

