### PR TITLE
Add paged exact decode and contributor GPU gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,8 @@ Describe the problem and the smallest coherent change that solves it.
 - [ ] New behavior has focused tests
 - [ ] README/docs reflect changed public claims or boundaries
 - [ ] No secrets, private artifacts, or credentials are included
+- [ ] SM90-source changes pass `CUDA Source Build`, or this PR does not change SM90 source
+- [ ] GPU behavior changes include `run_gpu_correctness_ci.py` device output
 
 For GPU/performance changes, provide the device, software versions, complete
 shape, exact command, timing protocol, correctness tolerance, paired baseline,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,36 @@ jobs:
       - name: Run CPU test suite
         run: python -m pytest -q
 
+  gpu-source-contract:
+    name: GPU source contract (no hardware)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install GPU source-contract dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu torch==2.5.1
+          python -m pip install triton==3.1.0 pytest numpy pyyaml
+          python -m pip install --no-deps -e .
+      - name: Validate shipped Triton and SM90 source
+        run: |
+          python benchmarks/check_gpu_source_contract.py
+          python -m pytest -q \
+            tests/test_gate0_projection_bitmask_triton.py \
+            tests/test_gate0_projection_mask_triton.py \
+            tests/test_gate0_projection_scan_triton.py \
+            tests/test_gate0_summary_scan_triton.py \
+            tests/test_qwen_o_proj_triton.py \
+            tests/test_seed_only_split_seed.py \
+            tests/test_sm90_exact_backend.py
+
   package:
     name: Source and wheel package
     runs-on: ubuntu-latest
@@ -88,7 +118,7 @@ jobs:
   required:
     name: Required checks
     if: always()
-    needs: [policy-integrity, unit-tests, package]
+    needs: [policy-integrity, unit-tests, gpu-source-contract, package]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -96,8 +126,10 @@ jobs:
         env:
           POLICY_RESULT: ${{ needs.policy-integrity.result }}
           TEST_RESULT: ${{ needs.unit-tests.result }}
+          GPU_SOURCE_RESULT: ${{ needs.gpu-source-contract.result }}
           PACKAGE_RESULT: ${{ needs.package.result }}
         run: |
           test "$POLICY_RESULT" = success
           test "$TEST_RESULT" = success
+          test "$GPU_SOURCE_RESULT" = success
           test "$PACKAGE_RESULT" = success

--- a/.github/workflows/gpu-source.yml
+++ b/.github/workflows/gpu-source.yml
@@ -1,0 +1,63 @@
+name: CUDA Source Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/gpu-source.yml"
+      - "benchmarks/check_sm90_cuda_compile.py"
+      - "stream_attention/backends/sm90/**"
+      - "stream_attention/kernels/**"
+      - "stream_attention/paged.py"
+      - "tests/test_paged_decode.py"
+      - "tests/test_sm90_exact_backend.py"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gpu-source.yml"
+      - "benchmarks/check_sm90_cuda_compile.py"
+      - "stream_attention/backends/sm90/**"
+      - "stream_attention/kernels/**"
+      - "stream_attention/paged.py"
+      - "tests/test_paged_decode.py"
+      - "tests/test_sm90_exact_backend.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cuda-source-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sm90-offline-build:
+    name: SM90 CUDA compile (no GPU)
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Offline-compile D64, D128, and TMA SM90 extensions
+        run: |
+          docker run --rm \
+            -e MAX_JOBS=2 \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel \
+            bash -lc '
+              set -euo pipefail
+              apt-get update -qq
+              apt-get install -y -qq git ninja-build
+              python -m pip install -q ninja
+              git clone --filter=blob:none --no-checkout https://github.com/pengcuo/FlashMLA-ETAP.git /tmp/flashmla-etap
+              cd /tmp/flashmla-etap
+              git sparse-checkout init --cone
+              git sparse-checkout set csrc/cutlass/include
+              git fetch --depth=1 origin 39e616041ae6fb1243a0f6ac891e72d576b640e5
+              git checkout 39e616041ae6fb1243a0f6ac891e72d576b640e5
+              cd /workspace
+              python benchmarks/check_sm90_cuda_compile.py \
+                --cutlass-root /tmp/flashmla-etap/csrc/cutlass \
+                --build-root /tmp/streamattn-sm90-build
+            '

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ claim type, correctness evidence, and performance evidence agree.
 4. Run the portable checks locally.
 5. Open a pull request using the repository template.
 6. Resolve the required `CI / Required checks` result and maintainer review.
+7. For SM90-source changes, resolve the path-triggered `CUDA Source Build`
+   check and attach runtime GPU evidence as described below.
 
 Do not include API keys, access tokens, private model artifacts, or credentials
 in issues, logs, commits, or benchmark output.
@@ -28,13 +30,22 @@ python benchmarks/check_wheel_contents.py dist/*.whl
 ```
 
 The GitHub workflow repeats policy integrity, the CPU suite on Python 3.10 and
-3.11, and source/wheel validation. GitHub-hosted CI does not claim GPU kernel
-qualification.
+3.11, and source/wheel validation. GPU-source changes also trigger free
+CPU-hosted Triton import checks and an offline SM90 CUDA build. These checks do
+not claim that a kernel executed correctly on hardware.
 
 ## GPU and performance changes
 
 CUDA, Triton, exact-native, and seed-only performance claims require an
-owner-run GPU artifact in addition to portable CI. Include:
+actual-device artifact in addition to portable CI. Start with:
+
+```bash
+python -m pip install -e .[dev,triton]
+python benchmarks/run_gpu_correctness_ci.py
+```
+
+For promoted SM90 exact-native changes, also run the harness with
+`--require-sm90 --cutlass-root /path/to/FlashMLA-ETAP/csrc/cutlass`. Include:
 
 - GPU model, driver, CUDA, PyTorch, Triton, and baseline versions;
 - `B`, `Hq`, `Hkv`, `N`, `D`, dtype, cache layout, and attention semantics;
@@ -43,6 +54,11 @@ owner-run GPU artifact in addition to portable CI. Include:
 - numerical reference, tolerances, finite-output and mutation checks;
 - the JSON artifact path or an attached artifact;
 - confirmation that every paid GPU job was stopped after completion.
+
+The current wheel is intentionally `py3-none-any`: it ships Triton/CUDA source
+and compiles device-specific code at runtime. Do not add per-GPU wheels unless
+the package begins embedding native binaries. See
+[`docs/gpu_ci_and_wheels.md`](docs/gpu_ci_and_wheels.md).
 
 Never describe a seed-only result as an exact-attention victory. Never promote
 one measured GPU cell into a universal device, model, or shape claim. New

--- a/README.md
+++ b/README.md
@@ -1,560 +1,467 @@
-# StreamAttn: Native Streaming Attention Engine
+# StreamAttn
 
 [![CI](https://github.com/MagellaX/StreamAttn/actions/workflows/ci.yml/badge.svg)](https://github.com/MagellaX/StreamAttn/actions/workflows/ci.yml)
+[![CUDA Source Build](https://github.com/MagellaX/StreamAttn/actions/workflows/gpu-source.yml/badge.svg)](https://github.com/MagellaX/StreamAttn/actions/workflows/gpu-source.yml)
 
-A self-owned attention engine built around single-pass streaming attention and
-online softmax. StreamAttn now contains native exact-decode and model-validated
-reduced-work decode paths; FlashInfer and FlashAttention are benchmark/reference
-backends rather than required serving dependencies. The general fused training
-path still uses running log-sum-exp accumulators to achieve O(N) auxiliary
-memory with numerically stable softmax normalization.
+**A native attention engine for exact streaming attention and model-validated
+reduced-work decode.**
 
-This repository provides:
-- A production-oriented `StreamAttention` module for drop-in use in transformer models
-- A fused online softmax kernel in Triton with safe PyTorch SDPA fallbacks
-- A FlashAttention-3 baseline wrapper
-- Benchmark and accuracy CLIs for reproducible comparisons
-- Utilities for memory profiling and KV-cache compression
-- Optional integration helpers for Hugging Face models
+StreamAttn owns its attention kernels. Its default native serving path does not
+call FlashInfer or FlashAttention; those projects are comparison baselines. At
+runtime, StreamAttn can compute exact attention over the full KV cache or, for
+an explicitly calibrated model/shape cell, execute a much smaller seed-only
+schedule and fail closed to exact attention when the cell does not match.
 
-## Recent Updates
+The common foundation is single-pass streaming attention with online softmax:
+K/V tiles are consumed once, numerically stable running statistics are updated
+on the fly, and the full attention matrix is never materialized.
 
-- Added guarded SM90 exact-native BF16 decode families for D64/G4, D64/G8, and
-  D128/G4. These kernels compute attention over every KV token and beat
-  FlashInfer on the explicitly promoted H100 cells.
-- Added a Qwen2.5-3B 32K/B8 product fast-path candidate measuring `1.193x`
-  actual-model decode speedup on H100 over 32 validated steps. Stress and
-  unknown request tiers remain exact-native.
-- Added a strict 128-step `verified_auto` candidate measuring `1.157x` actual
-  model speedup with zero top1/sample changes and all distribution gates
-  passing. Its bucket-step canary is offline-calibrated, so it is not yet a
-  general runtime verifier.
-- Evaluated TMA data movement and an architecture-valid warp-specialized D128
-  QK+PV mainloop. Both lost to the promoted cooperative kernel, so neither is
-  registered for serving.
-- Added a single-sweep Triton backward path (streaming dQ/dK/dV using saved `lse`) that mirrors the forward pass, including masks, dropout, and ALiBi.
-- Triton forward now supports boolean/additive masks, dropout, deterministic Philox seeding, and ALiBi bias without SDPA fallback.
-- Expanded tests/docs covering mask/dropout/ALiBi parity plus deterministic mode usage.
+> **Project status:** research engine with guarded H100 routes. StreamAttn has
+> apples-to-apples exact decode wins over FlashInfer on promoted shapes and a
+> measured model-level Qwen decode win on a validated request tier. It is not a
+> universal replacement for FlashInfer, FlashAttention, or a full serving
+> runtime yet.
 
-## Measured H100 Status
+## Why StreamAttn Exists
 
-The table below reports guarded results, not universal backend claims. Exact
-rows compare full all-token BF16 decode against FlashInfer 0.6.12. Model rows
-compare complete Qwen decode steps against the dense Hugging Face model path.
-
-| Route | Measured scope | Speedup | Status |
-|---|---|---:|---|
-| Exact native D64/G8 | 7 H100 cells, B2-B8, 16K-64K | `1.025x-1.432x` | promoted per-cell |
-| Exact native D64/G4 | 14 H100 cells, B1-B16, 16K-64K | `1.027x-1.449x` | promoted per-cell |
-| Exact native D128/G4 | 6 H100 cells, B4-B16, 16K-64K | `1.002x-1.012x` | promoted per-cell |
-| Qwen2.5-3B seed fast path | 32K, B8, validated buckets, 32 steps | `1.193x` | product candidate |
-| Qwen2.5-3B verified auto | 32K, B8, validated suite, 128 steps | `1.157x` | strict pass; offline canary |
-
-All unlisted exact shapes fail closed to another StreamAttn exact path or remain
-unsupported. The model route sends adversarial stress and unknown risk tiers to
-exact-native. No A100, B200, paged-KV, FP8, or universal model-family claim is
-made by these H100 measurements.
-
-
-
-## Installation
-
-The project depends on PyTorch (CUDA optional) and Triton (optional for the custom fused kernel).
-
-```bash
-# Editable install (preferred for development)
-pip install -e .
-
-# Optional extras
-pip install -e .[hf]        # Hugging Face integration helpers
-pip install -e .[triton]    # Triton kernels on supported Linux/x86-64 systems
-pip install -e .[dev]       # Test and package-validation tooling
-```
-
-Notes:
-- If the environment is system-managed, you may need to pass `--break-system-packages` to pip or use a virtual environment.
-- Triton is optional. If Triton is not available, the implementation falls back to PyTorch SDPA (flash backend on CUDA where available).
-
-
-## Quick Start
-
-```python
-import torch
-from stream_attention import StreamAttention, StreamAttentionConfig
-
-# Configure the attention
-config = StreamAttentionConfig(
-    num_heads=32,
-    head_dim=128,
-    tile_size_q=128,
-    tile_size_k=64,
-    use_qkv_projections=True
-)
-
-# Create the module
-attention = (StreamAttention(config).cuda() if torch.cuda.is_available() else StreamAttention(config))
-
-# Hidden-states path (with internal Q,K,V projections)
-batch_size, seq_len = 2, 1024
-hidden_dim = config.num_heads * config.head_dim
-x = torch.randn(batch_size, seq_len, hidden_dim, device=attention.attention.device, dtype=(torch.float16 if torch.cuda.is_available() else torch.float32))
-
-with torch.no_grad():
-    y = attention(hidden_states=x)
-print(y.shape)
-
-# Explicit Q,K,V path (supports attn_mask/dropout/ALiBi in Triton, falling back to SDPA when needed)
-q = torch.randn(batch_size, seq_len, config.num_heads, config.head_dim, device=x.device, dtype=x.dtype)
-k = torch.randn_like(q)
-v = torch.randn_like(q)
-with torch.no_grad():
-    # Example boolean mask [B, S_k]
-    key_padding_mask = torch.ones(batch_size, seq_len, dtype=torch.bool, device=x.device)
-    key_padding_mask[:, -16:] = False  # mask out last 16 positions
-    y_qkv = attention(q, k, v, causal=True, attention_mask=key_padding_mask)
-print(y_qkv.shape)
-```
-
-## Seed-Only Serving Wedge
-
-The first deployable StreamAttn decode route is intentionally narrow and
-fail-closed: Qwen2.5-0.5B layer 8, post-RoPE true-GQA tensors, 32K KV bucket,
-fp16, batch >= 4. It uses the packaged seed-only policy when the request
-matches and otherwise stays inside StreamAttn exact-native mode. FlashInfer is
-kept as a benchmark/reference injection, not a required serving fallback.
-
-Validated seed-only cells are indexed by
-`stream_attention/policies/registry.json`. Use
-`list_packaged_gate0_seed_only_batched_policies()` or
-`find_packaged_gate0_seed_only_batched_policies(...)` to discover green routes
-before loading an artifact. Today the registry contains sixteen green
-Qwen-family 32K cells: six Qwen2.5-0.5B cells (L1, L2, L5, L6, L8, L18), two
-Qwen2.5-1.5B cells (L0, L3), and eight Qwen2.5-3B cells (L0, L14, L16, L24,
-L26, L27, L29, L35). New frontier-model or additional-layer routes should enter
-through this registry only after their runtime and distribution-safety artifacts
-pass.
-
-```python
-from stream_attention import StreamAttnSeedOnlyDecodeService
-
-service = StreamAttnSeedOnlyDecodeService.from_packaged()
-
-out, info = service.run(q, k_cache, v_cache, mode="auto")
-print(info.to_dict())
-```
-
-CPU-safe fail-closed smoke:
-
-```bash
-python examples/seed_only_serving_decode.py --batch 4 --kv-len 128 --dtype fp32
-```
-
-Real serving-shape smoke with FlashInfer as an external reference backend:
-
-```bash
-python examples/seed_only_serving_decode.py --backend flashinfer --device cuda --batch 4 --kv-len 32768 --dtype fp16
-```
-
-## Engine Direction
-
-The narrow Qwen L8 route is the first executable wedge, not the final goal.
-StreamAttn is being shaped as a self-owned attention serving engine:
-
-- `streamattn_exact_native`: exact decode owned by StreamAttn. It starts as the
-  internal dense reference path and is the replacement point for TK/CUDA exact
-  kernels.
-- `gate0_seed_only_batched`: the first optimized native mode, enabled only for
-  validated logit-safe cells.
-- FlashInfer and FlashAttention-class kernels are development baselines and
-  reference backends, not required serving fallbacks.
-- General frontier-model coverage requires a policy compiler over model,
-  layer, KV-length, batch, dtype, GQA/MQA/MHA shape, and device buckets.
-
-### Exact-native H100 backend
-
-The promoted SM90 backend maps exact GQA decode into transposed WGMMA:
+Fast exact kernels answer this question:
 
 ```text
-context tokens  -> WGMMA M dimension
-query heads     -> WGMMA N dimension
+How efficiently can the GPU compute all requested attention work?
+```
+
+StreamAttn also asks:
+
+```text
+What is the cheapest native attention route that is valid for this request?
+```
+
+That produces three decode modes:
+
+| Mode | Work performed | Semantics | Current use |
+|---|---|---|---|
+| `exact_native` | All KV tokens | Exact attention, within numerical tolerance | Default and fail-closed route |
+| `seed_only_native` | A small sink/middle/recent seed set | Approximate; only for a packaged, validated policy cell | Explicit opt-in and calibrated serving |
+| `verified_auto` | Seed-only when policy invariants match, otherwise exact | Policy-verified, fail-closed routing | Default planning mode; live generic verification is still research |
+
+StreamAttn is therefore not just another sparse mask. The engine owns the
+kernel, policy artifact, fixed-buffer plan, route decision, and exact fallback.
+
+## What Is Proven Today
+
+### Exact native decode
+
+The promoted SM90 kernels compute full-context GQA decode and use online
+softmax plus exact split-state merging. These are direct comparisons against
+FlashInfer 0.6.12 on H100:
+
+| Shape family | Measured region | StreamAttn speedup | Status |
+|---|---|---:|---|
+| D64, GQA group 8 | 7 cells; B2-B8; 16K-64K KV | `1.025x-1.432x` | Promoted per cell |
+| D64, GQA group 4 | 14 cells; B1-B16; 16K-64K KV | `1.027x-1.449x` | Promoted per cell |
+| D128, GQA group 4 | 6 cells; B4-B16; 16K-64K KV | `1.002x-1.012x` | Promoted per cell |
+
+The exact backend uses transposed WGMMA so that long context occupies the
+hardware-friendly matrix dimension:
+
+```text
+context tokens  -> WGMMA M
+query heads     -> WGMMA N
 head dimension  -> WGMMA K reduction
 ```
 
-It performs full-context QK, online softmax, PV, and exact split-state merge.
-The public runner plans and allocates once, reuses fixed buffers, and dispatches
-only measured cells from a discrete batch/context/shape table. FlashInfer is
-used only for paired comparison.
+See the measured phase diagrams for the actual promoted cells:
 
-The latest D128 investigation tested both a TMA copy floor and a 256-thread
-producer/consumer `cp.async` QK+PV mainloop. TMA lost every measured copy cell;
-after register rebalancing restored two blocks/SM, the best warp-specialized
-result was still `0.9714x` of the cooperative baseline. The serving backend
-therefore retains the cooperative D128 implementation. See:
+- [D64/G8 H100 phase diagram](docs/exact_native_h100_phase_diagram_20260818.md)
+- [D64/G4 H100 phase diagram](docs/exact_native_h100_g4_phase_diagram_20260818.md)
+- [D128/G4 H100 phase diagram](docs/exact_native_h100_d128_g4_phase_diagram_20260819.md)
 
-- `docs/exact_native_h100_phase_diagram_20260818.md`
-- `docs/exact_native_h100_g4_phase_diagram_20260818.md`
-- `docs/exact_native_h100_d128_g4_phase_diagram_20260819.md`
-- `docs/sm90_d128_pipeline_ablation_20260819.md`
+### Model-aware reduced-work decode
 
-The seed-only backend is guided by explicit kernel economics. For true GQA with
-group size `G = Hq / Hkv`, StreamAttn can intentionally duplicate tiny seed K/V
-reads across Q heads when:
+For calibrated Qwen-family cells, the seed-only backend reads a small set of
+sink, middle, and recent KV blocks. A representative 32K policy uses 384 seed
+tokens, or `1.17%` of the full context. In true GQA, duplicating those reads
+across query heads is still inexpensive when:
 
 ```text
 G * seed_tokens / kv_len << 1
 ```
 
-For the packaged Qwen L8 32K route this is about `8.2%`, while the seed window
-itself is only `384 / 32768 = 1.17%` of the KV cache. The autotuner in
-`benchmarks/profile_seed_kernel_mode_autotune.py` reports these ratios, CTA
-counts, and whether the next kernel should use head-private direct seed,
-head-private split-seed, or a GQA-shared seed path.
+For the original Qwen route, that ratio is about `8.2%` of exact KV traffic.
+The extra head-private work creates enough independent CTAs to occupy the GPU
+while avoiding most of the exact QK, softmax, and PV work.
 
-The first two-kernel split-seed prototype is intentionally diagnostic: it writes
-partial online-softmax states and merges them in a second kernel. The H100
-below-B8 artifact in `artifacts/seed_only_split_seed_below8_h100.json` shows
-this path is numerically correct against direct seed-only but not product
-profitable. On that run, direct seed already wins at B4, while split-seed loses
-to direct seed for every batch and does not recover B1/B2. Merge and extra
-launch overhead dominate, so batch `<4` needs a lower-overhead single-kernel
-CUDA/TK cooperative split design, not the current two-kernel Triton
-decomposition.
+Measured complete-model results on H100:
 
-The direct seed-only batch-threshold gate in
-`artifacts/seed_only_direct_below8_h100_gate.json` narrows that target further.
-On captured Qwen L8 32K rows, the raw direct seed kernel first beats the
-FlashInfer exact reference at batch 4, and the planned direct service path now
-clears the same product gate at batch 4. The ordinary wrapper route remains as
-a comparison path, but `StreamAttnSeedOnlyDecodeService` defaults to a bound
-planned-direct runner for eligible fixed-buffer CUDA decode loops. The measured
-native route rule is therefore:
+| Route | Scope | Speedup | Distribution result | Status |
+|---|---|---:|---|---|
+| Qwen2.5-3B fast path | 32K, B8, validated request suite, 32 decode steps | `1.193x` | Zero top-1/sample changes; KL max `9.96e-05` | Candidate |
+| Qwen2.5-3B `verified_auto` | 32K, B8, validated suite, 128 decode steps | `1.157x` | Zero top-1/sample changes; strict gates pass | Research candidate; offline canary |
 
-```text
-B >= 4: head_private_direct_seed
-B < 4: exact_native until a single-kernel cooperative split-seed path proves out
-```
+These rows compare complete model decode against the dense Hugging Face model,
+not just selected attention calls. Adversarial stress and unknown request tiers
+remain exact. The 128-step verifier currently uses an offline-calibrated
+trigger schedule, so it is evidence for the design rather than a general live
+verifier.
 
-The next expansion is not new sparse-attention policy work; it is extending
-that planned/native path across more layers, lengths, devices, and model
-families, while treating B1/B2 as a separate backend-kernel project.
+### What the numbers do not claim
 
-The artifact-driven policy compiler turns sweep/rollout evidence into policy
-cells and registry metadata:
+- StreamAttn is not universally faster than FlashInfer on every exact shape.
+- Seed-only speedups are not exact-kernel speedups; they come from validated
+  work avoidance.
+- No A100, B200, paged-KV, FP8, or non-Qwen model-family performance claim has
+  been promoted yet. A native paged-KV implementation exists, but its H100
+  phase diagram is still pending.
+- The repository does not currently claim a direct universal win over
+  FlashAttention training kernels.
+
+## Installation
+
+StreamAttn requires Python 3.10+ and PyTorch. Triton is optional for CPU use but
+required for the native CUDA paths.
 
 ```bash
-python benchmarks/compile_streamattn_seed_policy.py \
-  --sweep-json artifacts/gate0/seed_only_layer_sweep_l0_l23_b4_h100.json \
-  --closed-loop-dir artifacts/gate0 \
-  --summary-json artifacts/gate0/compiled_seed_policy_qwen25_05b_32k_b4_h100.json
+git clone https://github.com/MagellaX/StreamAttn.git
+cd StreamAttn
+
+# Development install
+python -m pip install -e ".[dev]"
+
+# Native Triton kernels on supported Linux/x86-64 systems
+python -m pip install -e ".[triton]"
+
+# Optional Hugging Face helpers
+python -m pip install -e ".[hf]"
 ```
 
-For the current Qwen2.5-0.5B 32K B4 evidence, the compiler reproduces the six
-green layers L1, L2, L5, L6, L8, and L18. It requires both the last-32 layer
-sweep gate and per-layer 32-step teacher-forced, greedy, and coupled top-p
-rollout gates before a cell can enter the registry.
+The package is currently a portable `py3-none-any` wheel. GPU kernels are
+compiled for the installed device at runtime, so separate A100/H100/B200 Python
+wheels are not needed.
 
-For new model buckets, use the Modal policy pipeline to run sweep, validate
-candidates, and compile a summary in one H100 job:
+## Quick Start
 
-```bash
-modal run benchmarks/modal_compile_streamattn_seed_policy.py \
-  --model Qwen/Qwen2.5-1.5B-Instruct \
-  --layers 0-27 \
-  --kv-len 32768 \
-  --batch-size 4 \
-  --output-dir artifacts/gate0/qwen25_15b_32k_b4
-```
+### One-shot exact decode
 
-The pipeline only runs closed-loop rollout for sweep-passing candidate layers.
-It writes the sweep, per-candidate rollout artifacts, compiled policy summary,
-and `seed_policy_pipeline_summary.json` into the output directory.
-
-Qwen2.5-3B is the current largest packaged Qwen-family expansion. The 32K/B4
-pipeline found ten candidate layers and packaged eight green layers: L0, L14,
-L16, L24, L26, L27, L29, and L35. The multi-layer threshold gate in
-`artifacts/gate0/qwen25_3b_32k_b4_runtime/threshold_layers_h100.json` confirms
-all eight cells are already profitable at B4 with the planned direct seed path,
-so these cells do not need the two-kernel split-seed path.
-
-Multi-layer safety is stricter than isolated per-layer safety. For Qwen2.5-3B,
-the strict B4 route bundle is seven layers:
-
-```text
-L0, L14, L16, L24, L26, L27, L35
-```
-
-The all-eight bundle including L29 kept top1/greedy/sample tokens stable but
-exceeded the strict KL gate. The seven-layer bundle passes teacher-forced,
-greedy, and coupled top-p rollout and is captured in
-`stream_attention/policies/qwen25_3b_32k_b4_seed_only_bundle.json`.
-
-To benchmark several validated layers against the same capture, pass `--layers`
-to the Modal threshold runner:
-
-```bash
-modal run benchmarks/modal_seed_only_wrapper_batch_threshold.py \
-  --model Qwen/Qwen2.5-3B-Instruct \
-  --layers 0,14,16,24,26,27,29,35 \
-  --kv-len 32768 \
-  --batch-sizes 4,8 \
-  --product-min-batch 4 \
-  --output-json artifacts/gate0/qwen25_3b_32k_b4_runtime/threshold_layers_h100.json
-```
-
-To validate a multi-layer route bundle in one model forward path:
-
-```bash
-modal run benchmarks/modal_gate0_seed_only_multi_layer_rollout.py \
-  --model Qwen/Qwen2.5-3B-Instruct \
-  --layers 0,14,16,24,26,27,35 \
-  --max-seq 32768 \
-  --batch-size 4 \
-  --steps 32 \
-  --output-json artifacts/gate0/qwen25_3b_32k_b4_multi_layer/drop_l29_rollout_h100.json
-```
-
-`StreamAttnSeedOnlyDecodeService.plan_direct_seed_only(...)` is the first step
-in that direction: it validates policy and tensor invariants once, binds fixed
-Q/K/V/output buffers, and returns a `StreamAttnSeedOnlyDirectRunner` whose
-steady-state `run()` path launches the prechecked direct seed kernel without
-per-step routing.
-
-The B4 promotion is backed by `artifacts/seed_only_direct_below8_h100_gate.json`
-for runtime and `artifacts/gate0/seed_only_b4_closed_loop_h100.json` for
-32-step teacher-forced, greedy, coupled top-p, and forced-same-token safety.
-
-The first actual-model decode speedup for the Qwen2.5-3B strict route uses the
-native routed cache prototype:
-
-```bash
-modal run benchmarks/modal_seed_only_route_bundle_decode.py \
-  --model Qwen/Qwen2.5-3B-Instruct \
-  --layers 0,14,16,24,26,27,35 \
-  --no-use-packaged-policies \
-  --batch-size 8 \
-  --max-seq 32768 \
-  --steps 32 \
-  --native-routed-cache
-```
-
-On H100 this measured `1.136x` full-model decode speedup with strict safety
-passing and zero routed-layer `DynamicCache.update` calls. StreamAttn now owns
-the routed K/V cache and mask-length bookkeeping for this route.
-
-A fused routed-layer path is also available:
-
-```bash
-modal run benchmarks/modal_seed_only_route_bundle_decode.py \
-  --model Qwen/Qwen2.5-3B-Instruct \
-  --layers 0,14,16,24,26,27,35 \
-  --no-use-packaged-policies \
-  --batch-size 8 \
-  --max-seq 32768 \
-  --steps 32 \
-  --native-routed-cache \
-  --fused-rope-append-seed
-```
-
-This fuses Qwen RoPE, native K/V append, and seed-only attention for routed
-layers. It was the intermediate `1.163x` actual-model result. The current
-validated-bucket preset also enables packed QKV projection, direct `o_proj`,
-mixed L2-S416 policy support, and measured per-layer kernel overrides:
-
-```bash
-modal run benchmarks/modal_seed_only_route_bundle_decode.py \
-  --model Qwen/Qwen2.5-3B-Instruct \
-  --product-fast-path qwen25_3b_b8_validated \
-  --batch-size 8 \
-  --max-seq 32768 \
-  --steps 32
-```
-
-On H100 this preset measured `1.1926x` complete-model decode speedup, zero
-top1/sample changes, and KL max `9.96e-05` over the 32-step validated suite.
-It is not a universal request route: adversarial stress and unknown risk tiers
-fail closed to exact-native.
-
-The unverified fast path did not pass the stricter 128-step margin gate despite
-zero top1/sample changes (`1.1638x`, KL max `1.039e-04`, top-5 overlap 3/5).
-The current `verified_auto` research candidate performs row-selective native
-exact refresh from an offline bucket-step canary. It passed all strict 128-step
-gates over 1,024 cases at `1.1569x` model speedup, with KL max `9.32e-05` and
-top-5 overlap at least 4/5. This proves that verification can preserve both
-strict safety and a model-level win, but the offline trigger schedule must be
-replaced by a selective live signal before general product deployment. See:
-
-- `stream_attention/policies/qwen25_3b_32k_b8_bucket_conditioned_route.json`
-- `stream_attention/policies/qwen25_3b_32k_b8_verified_auto_route.json`
-
-## Contributing
-
-Start with [CONTRIBUTING.md](CONTRIBUTING.md) and use the structured GitHub
-issue or pull-request templates. Every contribution must pass the stable
-`CI / Required checks` result, which aggregates policy integrity, CPU tests on
-Python 3.10/3.11, and package validation. GPU performance claims additionally
-require an owner-run device artifact with the shape, baseline, correctness
-gate, and timing protocol recorded explicitly.
-
-
-## API Reference
-
-### StreamAttention
-- Purpose: High-level module. Accepts either `hidden_states` ([B, T, H*D]) or explicit `(query, key, value)` ([B, T, H, D]).
-- Signature (selected):
-  - `forward(query, key, value, causal: bool=True, return_lse: bool=False, attention_mask: Optional[Tensor]=None, dropout_p: float=0.0, alibi_slopes: Optional[Tensor]=None, deterministic: Optional[bool]=None)` -> `Tensor` (and `lse` if requested)
-  - `benchmark(seq_len: int, batch_size: int=1, warmup: int=10, iterations: int=100)` -> metrics dict
-  - `set_deterministic(enabled: bool, seed: Optional[int]=None)` -> control deterministic dropout/mask behavior
-- Autograd: The Triton kernel now runs a single-sweep backward pass (streaming dQ/dK/dV using the saved `lse`) covering masks, dropout, and ALiBi. PyTorch SDPA is used only when Triton is unavailable.
-
-### Multihead-style wrapper
-Use `create_stream_attention` to obtain an attention layer with a familiar
-`nn.MultiheadAttention` interface. Triton kernels are used automatically when
-available, otherwise PyTorch's SDPA backend is selected:
+Decode tensors use `[batch, sequence, heads, head_dim]`. For autoregressive
+decode the query sequence is normally one token.
 
 ```python
 import torch
-from stream_attention import create_stream_attention
+import stream_attention as stream_attn
 
-mha = create_stream_attention(embed_dim=512, num_heads=8, batch_first=True)
-x = torch.randn(2, 16, 512)
-out, _ = mha(x, x, x)
+device = "cuda" if torch.cuda.is_available() else "cpu"
+dtype = torch.bfloat16 if device == "cuda" else torch.float32
+
+q = torch.randn(4, 1, 16, 64, device=device, dtype=dtype)
+k_cache = torch.randn(4, 32768, 2, 64, device=device, dtype=dtype)
+v_cache = torch.randn_like(k_cache)
+
+output, info = stream_attn.decode(
+    q,
+    k_cache,
+    v_cache,
+    mode="exact_native",
+)
+
+print(output.shape)
+print(info.backend_used)
 ```
 
-### FlashAttentionV3
-- Purpose: Baseline using PyTorch SDPA with the flash backend on CUDA, falling back gracefully on CPU.
-- Signature (selected):
-  - `forward(query, key, value, causal: bool=True)` → `Tensor`
-  - `benchmark(...)` → metrics dict
+On an unsupported native CUDA shape, the exact path uses the safe exact
+implementation available in the installed environment. Promoted serving cells
+are always explicit; StreamAttn does not infer a performance claim from a
+successful launch.
 
-### StreamAttentionConfig
-Selected fields (see source for full set):
-- `num_heads`, `head_dim`
-- `tile_size_q`, `tile_size_k`
-- `use_fp16`, `use_qkv_projections`, `qkv_bias`, `use_layer_norm`, `dropout`
-- `enable_distributed`
-- `max_sequence_length`
-- Ring/Star attention parameters for long-context variants
-- `.from_env()` reads `STREAM_ATTENTION_*` variables; see `.env.example`
+### Exact decode from a paged KV cache
 
+Paged decode accepts physical NHD or HND pages and a per-request block table.
+The native kernel resolves logical tokens to physical pages inside the
+online-softmax loop; it does not gather pages into a contiguous cache.
 
-## Benchmarking vs FlashAttention-3
+~~~python
+import torch
+import stream_attention as stream_attn
 
-Two CLIs are provided:
+q = torch.randn(4, 1, 16, 64, device="cuda", dtype=torch.bfloat16)
+k_pages = torch.randn(8192, 16, 2, 64, device="cuda", dtype=torch.bfloat16)
+v_pages = torch.randn_like(k_pages)
+page_table = torch.arange(
+    8192, device="cuda", dtype=torch.int32
+).view(4, 2048)
+sequence_lengths = torch.full(
+    (4,), 32768, device="cuda", dtype=torch.int32
+)
+
+cache = stream_attn.PagedKVCache(
+    key=k_pages,
+    value=v_pages,
+    page_table=page_table,
+    sequence_lengths=sequence_lengths,
+    layout="NHD",
+)
+
+plan = stream_attn.StreamAttnEngine().plan(
+    q,
+    cache,
+    mode="exact_native",
+)
+output, info = plan.run()
+~~~
+
+The page table and sequence-length buffers may be updated in place between
+steps, provided they continue to satisfy the bounds validated during planning.
+The current paged backend is exact and allocation-free after planning, but it
+is not yet a promoted performance route.
+
+### Plan once for a decode loop
+
+Stable serving loops should validate shapes and policy once, then reuse the
+same Q/K/V and output buffers:
+
+```python
+import torch
+from stream_attention import StreamAttnEngine
+
+q = torch.randn(4, 1, 14, 64, device="cuda", dtype=torch.float16)
+k_cache = torch.randn(4, 32768, 2, 64, device="cuda", dtype=torch.float16)
+v_cache = torch.randn_like(k_cache)
+
+engine = StreamAttnEngine(
+    policy_name="qwen25_05b_l8_32k_seed_only_batched",
+    model_id="Qwen/Qwen2.5-0.5B-Instruct",
+    layer_id=8,
+)
+
+plan = engine.plan(
+    q,
+    k_cache,
+    v_cache,
+    mode="verified_auto",
+)
+
+# Update q/k_cache/v_cache contents in place between decode steps.
+output, info = plan.run()
+print(info.backend_used, plan.reason)
+```
+
+`verified_auto` selects seed-only only when model, layer, dtype, batch, KV
+bucket, GQA shape, device, and policy constraints match. Otherwise it executes
+exact attention. `seed_only_native` is the strict explicit mode and raises when
+the requested seed route cannot be planned.
+
+### General forward and training module
+
+`StreamAttention` provides the fused online-softmax forward/backward path for
+standard transformer experimentation:
+
+```python
+import torch
+from stream_attention import StreamAttention, StreamAttentionConfig
+
+config = StreamAttentionConfig(num_heads=8, head_dim=64)
+attention = StreamAttention(config).cuda()
+
+q = torch.randn(2, 1024, 8, 64, device="cuda", dtype=torch.float16,
+                requires_grad=True)
+k = torch.randn_like(q)
+v = torch.randn_like(q)
+
+output = attention(q, k, v, causal=True)
+output.square().mean().backward()
+```
+
+The Triton path supports boolean/additive masks, dropout, deterministic Philox
+seeding, ALiBi, and a streaming backward pass. Unsupported environments fall
+back to PyTorch SDPA.
+
+## Decode Request Lifecycle
+
+The native engine deliberately separates model-specific work from attention:
+
+```text
+request
+  -> model adapter projects Q/K/V and applies RoPE
+  -> adapter appends K/V to its cache
+  -> StreamAttn validates or reuses a fixed-buffer plan
+       -> exact_native: stream every KV tile
+       -> seed_only_native: stream the validated seed blocks
+       -> verified_auto: choose seed only on a matching policy cell
+  -> online softmax produces [B, 1, Hq, D]
+  -> model adapter applies output projection
+  -> sampler chooses the next token
+```
+
+Planning is kept outside the steady-state loop. The hot path reuses workspaces,
+seed schedules, output buffers, and native cache views instead of rebuilding
+Python metadata on every token.
+
+## Online Softmax
+
+For each query row, StreamAttn carries a running maximum `m`, normalizer `l`,
+and weighted value numerator `n`. When a new score tile arrives:
+
+```text
+m_new = max(m, max(scores_tile))
+alpha = exp(m - m_new)
+p     = exp(scores_tile - m_new)
+
+l = alpha * l + sum(p)
+n = alpha * n + p @ V_tile
+m = m_new
+
+output = n / l
+```
+
+This is numerically stable, requires linear auxiliary memory, and composes
+across split tiles. Exact mode applies it to every KV tile. Seed-only mode uses
+the same normalization over the policy-selected KV set.
+
+## Policy Boundaries
+
+Packaged policy cells live in
+[`stream_attention/policies/registry.json`](stream_attention/policies/registry.json).
+Each cell records the model and layer, tensor space, dtype, KV bucket, minimum
+batch, head geometry, seed schedule, safety gates, and measured performance.
+
+A layer that passes in isolation is not automatically safe in a multi-layer
+route. Route bundles are evaluated with teacher-forced replay, greedy rollout,
+coupled sampling, and adversarial stress prompts. Failed or unknown cells are
+not silently promoted.
+
+The dynamic-selector research follows the same rule: query-aware block
+selection is interesting only if its selection overhead, model-level safety,
+and net decode latency all pass. Research utilities are not part of the default
+serving path.
+
+## Benchmarking
+
+The lightweight package CLIs exercise the general fused attention module:
 
 ```bash
-# Performance comparison across sequence lengths
-stream-attention-benchmark --seq 512 1024 2048 4096 --batch 1 --heads 8 --dim 64 --warmup 10 --iters 50
+stream-attention-benchmark \
+  --seq 512 1024 2048 4096 \
+  --batch 1 --heads 8 --dim 64 --warmup 10 --iters 50
 
-# Accuracy sanity check on random inputs
-stream-attention-test --seq 1024 --batch 2 --heads 8 --dim 64 --dtype fp16
+stream-attention-test \
+  --seq 1024 --batch 2 --heads 8 --dim 64 --dtype fp16
 ```
 
-Behavior and methodology:
-- On CUDA, the baseline uses PyTorch SDPA with the flash backend (FlashAttention-3 path). On CPU, both implementations use SDPA in fp32.
-- Metrics reported: per-iteration latency, estimated TFLOPS, and approximate bandwidth based on tensor traffic. Measurements are averaged after warmup.
-- The fused kernel uses Triton on CUDA for forward and single-sweep backward when the custom path is available. Mask, dropout, ALiBi, and deterministic replay are covered by the Triton path; SDPA remains the safety fallback when Triton or a requested shape/backend is unavailable.
-- For reproducibility, fix random seeds, pin CUDA clocks if applicable, and isolate runs. Actual performance depends on GPU architecture, drivers, and PyTorch/Triton versions.
+For native decode research, start with the profiler help instead of assuming a
+default shape:
 
-Example output (format):
-```
-SeqLen  Fused(ms)  Fused(TF)  FA3(ms)  FA3(TF)  FA3/Fused(ms)
-  1024      0.650     90.12     0.700     83.70          1.08
+```bash
+python benchmarks/profile_transposed_wgmma_exact_qk.py --help
+python benchmarks/profile_paged_exact_decode.py --help
+python benchmarks/profile_seed_only_route_bundle_decode.py --help
+python benchmarks/profile_seed_kernel_mode_autotune.py --help
 ```
 
+A publishable performance result should record:
 
-## Kernel Design (Fused Online Softmax)
+- GPU model, CUDA, driver, PyTorch, Triton, and baseline versions
+- batch, KV length, Q/KV heads, head dimension, dtype, and cache layout
+- warmup, repetitions, timing method, and clock/power conditions
+- numerical tolerance or model-distribution gate
+- paired raw timings, not speedup alone
 
-The fused kernel streams over K/V tiles while maintaining per-query running statistics for online softmax, avoiding materialization of the full attention matrix.
+FlashInfer is the exact decode reference used by the promoted H100 phase
+diagrams. PyTorch SDPA is the general correctness fallback and training
+reference. FlashAttention-class implementations remain external references,
+not hidden StreamAttn dependencies.
 
-- Tiling:
-  - Queries are processed in blocks of `TILE_M` (configurable via autotune); keys/values are streamed in tiles of `TILE_N`.
-  - Head dimension `D` is processed vectorized. The kernel uses `tl.dot(q, tl.trans(k))` to compute `QK^T` for each tile.
+## Supported Surface
 
-- Online softmax with log-sum-exp:
-  - Maintain `running_max[m]`, `acc_num[m, :]`, `acc_den[m]` for each query row `m`.
-  - For each K/V tile:
-    - `tile_max = max_j qk[m, j]`, `new_max = max(running_max[m], tile_max)`
-    - Rescale previous accumulators by `exp(running_max - new_max)`
-    - `exp_qk = exp(qk - new_max)`
-    - `acc_num += exp_qk @ V_tile`, `acc_den += sum(exp_qk, axis=tile)`
-    - `running_max = new_max`
-  - Final output: `acc_num / acc_den[:, None]`. Log-sum-exp `lse = running_max + log(acc_den)` may be returned for analysis.
+| Area | Current support |
+|---|---|
+| Python | 3.10+ |
+| PyTorch | 2.1+ |
+| CPU | Correctness and SDPA fallback |
+| Native GPU evidence | NVIDIA H100 / SM90 |
+| Exact decode | Contiguous BF16 KV; guarded D64/D128 GQA cells plus generic exact fallback |
+| Paged exact decode | Direct NHD/HND page-table kernel; experimental until paired H100 gates pass |
+| Reduced-work decode | Packaged Qwen-family 32K cells; request-tier and route-bundle restrictions apply |
+| Forward/backward | Triton online-softmax path with masks, dropout, ALiBi, and autograd |
+| Distributed research | Ring and Star attention prototypes |
+| Not yet promoted | A100, B200, paged KV, FP8 seed cache, second model family |
 
-- Autotuning:
-  - Multiple Triton configurations for `TILE_M`/`TILE_N`, warps, and stages are provided.
-  - Kernel grid: `(ceil_div(M, TILE_M), batch, heads)`
+## Repository Guide
 
-- Numerical stability:
-  - The log-sum-exp re-centering preserves stability across tiles and long sequences.
-  - On CPU, fp16/bf16 inputs are upcast to fp32 where necessary.
+```text
+stream_attention/
+  engine.py                 public fixed-buffer decode engine
+  decode.py                 native modes, planning, and fail-closed service
+  backends/sm90/            promoted Hopper exact kernels and dispatch
+  kernels/                  Triton/CUDA attention kernels
+  policies/                 calibrated policy cells and route bundles
+  core/                     general forward/backward attention modules
+  integration/              model integration helpers
 
-- Backward:
-  - The Triton autograd path recomputes QK tiles using saved `lse`, streams dQ/dK/dV, and avoids materializing the attention matrix. PyTorch SDPA remains the fallback for unsupported environments.
-
-
-## Distributed and Long-Context Variants
-
-- Ring Attention (`stream_attention/core/ring_attention.py`): partitions sequences across devices with overlapped communication and computation. Suitable for near-infinite contexts with linear memory scaling.
-- Star Attention (`stream_attention/core/star_attention.py`): two-phase approach (context encoding, then query processing with aggregated attention). Reduces end-to-end latency for long sequences while preserving accuracy.
-
-Both modules follow numerically stable aggregation strategies (log-sum-exp weighted combining) and can be paired with KV compression.
-
-
-## Memory Optimization Utilities
-
-- KV-cache compression strategies: importance-based, chunk-based, quantized, and hybrid.
-- Gradient checkpointing helpers for sequential modules.
-- `MemoryProfiler` to snapshot and report peak allocations.
-
-Example:
-```python
-from stream_attention.utils.memory import create_kv_compressor
-comp = create_kv_compressor('hybrid')
-ck, cv, stats = comp.compress(keys, values, compression_ratio=8.0)
-print(stats)
+benchmarks/                 profilers, policy compilers, and evidence tools
+docs/                       phase diagrams and research decisions
+examples/                   minimal usage and integration examples
+tests/                      CPU, policy, API, and CUDA-gated tests
 ```
 
+The detailed experiment history is intentionally kept in `docs/` rather than
+the README. Start with:
 
-## Hugging Face Integration
+- [Documentation index](docs/Index.md)
+- [Qwen2.5-3B route evidence](docs/qwen25_3b_32k_b4_seed_policy.md)
+- [Dynamic selector findings](docs/qwen25_3b_dynamic_selector_findings.md)
+- [D128 pipeline ablation](docs/sm90_d128_pipeline_ablation_20260819.md)
+- [Paged exact decode](docs/paged_exact_decode.md)
+- [Literature and backend decision ledger](docs/streamattn_literature_decision_ledger.md)
 
-Helpers are provided to replace attention modules in HF models:
+## Contributing
 
-```python
-from transformers import AutoModel
-from stream_attention.integration.hf import replace_llama_attention
-from stream_attention import StreamAttentionConfig
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. The
+required CI result covers policy integrity, Python 3.10/3.11 CPU tests, package
+validation, and GPU-source contracts. CUDA-source changes also trigger an
+offline SM90 compile check on a standard hosted runner; contributors are not
+expected to pay for GPU CI.
 
-model = AutoModel.from_pretrained("meta-llama/Llama-2-7b-hf")
-cfg = StreamAttentionConfig(num_heads=model.config.num_attention_heads, head_dim=model.config.hidden_size // model.config.num_attention_heads)
-num_replaced = replace_llama_attention(model, cfg)
-print(f"Replaced {num_replaced} attention modules")
+Actual-device performance claims still require a reproducible hardware
+artifact. The contributor harness and evidence requirements are documented in
+[GPU CI and wheels](docs/gpu_ci_and_wheels.md).
+
+Useful local checks:
+
+```bash
+python -m pytest -q
+python benchmarks/check_gpu_source_contract.py
+python -m build
+python benchmarks/check_wheel_contents.py dist/*.whl
 ```
-
-
-## Supported Environments
-
-- PyTorch 2.0+
-- CUDA: fp16 and bf16 supported via SDPA (flash backend where available). Triton kernel requires CUDA.
-- CPU: falls back to SDPA with fp32 compute for correctness and stability.
-- Distributed: query sharding is supported in the fused module for multi-GPU; ring/star provides long-context strategies.
-
 
 ## Roadmap
 
-- Native RoPE / relative positional bias fusion in the Triton kernel (forward + backward)
-- Advanced pipelining (warp specialization, asynchronous staging) and Hopper-specific paths (WGMMA/TMA)
-- Extended autotune coverage across architectures and sequence regimes
-- Optional FP8 path with block-wise scaling
+The project has completed the first proof: StreamAttn-owned exact kernels can
+beat a strong exact decode baseline on guarded H100 cells, and a calibrated
+reduced-work route can speed up complete model decode. The next milestones are:
 
+1. Stabilize the engine surface around `stream_attn.decode(...)`, then add
+   first-class `prefill(...)` and `train(...)` entry points.
+2. Replace offline verification schedules with a selective live runtime
+   verifier.
+3. Add a second model family to test whether policy discovery generalizes
+   beyond Qwen.
+4. Gate paged-KV decode on H100, then expand exact-native evidence to A100 and
+   B200.
+5. Improve B1/B2 economics with a single-kernel cooperative seed path.
+6. Promote query-aware dynamic selection only where it beats exact fallback
+   after selector overhead.
+7. Evaluate FP8/FP4 seed caches under the same distribution-level gates.
 
-## Development and Testing
+The long-term API target is:
 
-- Benchmarks: `stream-attention-benchmark` CLI
-- Accuracy checks: `stream-attention-test` CLI
-- Examples: `examples/` directory includes basic usage, integrations, and long-context runs
-- Environment variables: see `.env.example`; `StreamAttentionConfig.from_env()` can bootstrap configuration
+```python
+stream_attn.decode(...)
+stream_attn.prefill(...)
+stream_attn.train(...)
+```
 
+with native exact, seed-only, adaptive, and verified routes behind one engine.
 
 ## License
 
-Apache License. See `LICENSE` for details.
+Apache-2.0. See [LICENSE](LICENSE).

--- a/benchmarks/check_gpu_source_contract.py
+++ b/benchmarks/check_gpu_source_contract.py
@@ -1,0 +1,89 @@
+"""Validate GPU source imports and architecture contracts without a GPU."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from typing import Any
+
+
+TRITON_MODULES = (
+    "stream_attention.core.fused_online_attention",
+    "stream_attention.kernels.certified_fwd_triton",
+    "stream_attention.kernels.gate0_compact_repair_triton",
+    "stream_attention.kernels.gate0_exact_refresh_triton",
+    "stream_attention.kernels.gate0_launch_floor_triton",
+    "stream_attention.kernels.gate0_projection_bitmask_triton",
+    "stream_attention.kernels.gate0_projection_mask_triton",
+    "stream_attention.kernels.gate0_projection_scan_triton",
+    "stream_attention.kernels.gate0_seed_only_triton",
+    "stream_attention.kernels.gate0_summary_scan_triton",
+    "stream_attention.kernels.gate1_fwd_triton",
+    "stream_attention.kernels.gate1_inline_projection_fwd_triton",
+    "stream_attention.kernels.gate1_inline_projection_splitk_triton",
+    "stream_attention.kernels.gate1_mass_fwd_triton",
+    "stream_attention.kernels.metadata_triton",
+    "stream_attention.kernels.metadata_update_triton",
+    "stream_attention.kernels.paged_exact_triton",
+    "stream_attention.kernels.qwen_o_proj_triton",
+)
+
+
+def check_gpu_source_contract() -> dict[str, Any]:
+    failures: list[str] = []
+    imported: list[str] = []
+
+    try:
+        triton = importlib.import_module("triton")
+    except Exception as exc:  # pragma: no cover - exercised by CI failures
+        failures.append(f"triton_import:{type(exc).__name__}:{exc}")
+        triton_version = None
+    else:
+        triton_version = getattr(triton, "__version__", "unknown")
+
+    for name in TRITON_MODULES:
+        try:
+            module = importlib.import_module(name)
+        except Exception as exc:  # pragma: no cover - exercised by CI failures
+            failures.append(f"module_import:{name}:{type(exc).__name__}:{exc}")
+            continue
+        imported.append(name)
+        if hasattr(module, "TRITON_AVAILABLE") and not module.TRITON_AVAILABLE:
+            failures.append(f"triton_disabled:{name}")
+
+    try:
+        from stream_attention.backends.sm90.transposed_gqa_exact_sources import (
+            CUDA_SOURCE,
+            cuda_source_for_head_dim,
+        )
+    except Exception as exc:  # pragma: no cover - exercised by CI failures
+        failures.append(f"sm90_source_import:{type(exc).__name__}:{exc}")
+    else:
+        source_d64 = cuda_source_for_head_dim(64)
+        source_d128 = cuda_source_for_head_dim(128)
+        if source_d64 is not CUDA_SOURCE:
+            failures.append("sm90_d64_source_identity")
+        if source_d64 == source_d128:
+            failures.append("sm90_d128_source_not_specialized")
+        for token in ("wgmma", "sm90_64x8x16", "streamattn_transposed"):
+            if token not in source_d64.lower():
+                failures.append(f"sm90_source_token_missing:{token}")
+
+    return {
+        "schema": "streamattn.gpu_source_contract.v1",
+        "passed": not failures,
+        "triton_version": triton_version,
+        "modules_imported": imported,
+        "failures": failures,
+    }
+
+
+def main() -> None:
+    result = check_gpu_source_contract()
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/check_sm90_cuda_compile.py
+++ b/benchmarks/check_sm90_cuda_compile.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 def compile_sm90_sources(*, cutlass_root: Path, build_root: Path) -> dict[str, object]:

--- a/benchmarks/check_sm90_cuda_compile.py
+++ b/benchmarks/check_sm90_cuda_compile.py
@@ -1,0 +1,70 @@
+"""Offline-compile StreamAttn SM90 extensions without executing GPU code."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest import mock
+
+
+def compile_sm90_sources(*, cutlass_root: Path, build_root: Path) -> dict[str, object]:
+    import torch.utils.cpp_extension as cpp_extension
+
+    from stream_attention.backends.sm90 import tma_pipeline_floor
+    from stream_attention.backends.sm90 import transposed_gqa_exact
+
+    build_root.mkdir(parents=True, exist_ok=True)
+    components: list[str] = []
+    sentinel = object()
+
+    # load_inline compiles before importing the shared object. Replacing only
+    # the import step preserves the complete nvcc/ptxas build while allowing it
+    # to run on a standard CPU-only GitHub runner.
+    with mock.patch.object(
+        cpp_extension, "_import_module_from_library", return_value=sentinel
+    ):
+        transposed_gqa_exact._EXTENSIONS.clear()
+        for head_dim in (64, 128):
+            extension = transposed_gqa_exact.compile_transposed_gqa_exact_extension(
+                cutlass_root=cutlass_root,
+                build_dir=build_root / f"exact-d{head_dim}",
+                head_dim=head_dim,
+                verbose=True,
+            )
+            if extension is not sentinel:
+                raise RuntimeError(f"unexpected exact D{head_dim} compile result")
+            components.append(f"exact_d{head_dim}")
+
+        tma_pipeline_floor._EXTENSIONS.clear()
+        extension = tma_pipeline_floor.compile_tma_pipeline_floor_extension(
+            cutlass_root=cutlass_root,
+            build_dir=build_root / "tma-floor",
+            verbose=True,
+        )
+        if extension is not sentinel:
+            raise RuntimeError("unexpected TMA floor compile result")
+        components.append("tma_pipeline_floor")
+
+    return {
+        "schema": "streamattn.sm90_cuda_compile.v1",
+        "passed": True,
+        "target": "sm_90a",
+        "components": components,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cutlass-root", type=Path, required=True)
+    parser.add_argument("--build-root", type=Path, default=Path("/tmp/streamattn-sm90-build"))
+    args = parser.parse_args()
+    result = compile_sm90_sources(
+        cutlass_root=args.cutlass_root,
+        build_root=args.build_root,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/check_wheel_contents.py
+++ b/benchmarks/check_wheel_contents.py
@@ -11,6 +11,10 @@ from pathlib import Path
 
 REQUIRED_FILES = {
     "stream_attention/__init__.py",
+    "stream_attention/backends/sm90/transposed_gqa_exact.py",
+    "stream_attention/backends/sm90/transposed_gqa_exact_sources.py",
+    "stream_attention/kernels/gate0_seed_only_triton.py",
+    "stream_attention/kernels/qwen_o_proj_triton.py",
     "stream_attention/policies/registry.json",
 }
 FORBIDDEN_PREFIXES = ("artifacts/", "benchmarks/", "tests/")
@@ -24,6 +28,8 @@ EXPECTED_REPOSITORY_URL = "https://github.com/MagellaX/StreamAttn"
 
 def check_wheel(path: Path) -> dict[str, object]:
     failures: list[str] = []
+    if not path.name.endswith("-py3-none-any.whl"):
+        failures.append(f"wheel_tag_not_portable:{path.name}")
     with zipfile.ZipFile(path) as wheel:
         names = set(wheel.namelist())
         for required in sorted(REQUIRED_FILES):
@@ -61,6 +67,10 @@ def check_wheel(path: Path) -> dict[str, object]:
                 failures.append("metadata_triton_is_mandatory")
         if len(wheel_files) != 1:
             failures.append(f"wheel_file_count:{len(wheel_files)}")
+        else:
+            wheel_metadata = BytesParser().parsebytes(wheel.read(wheel_files[0]))
+            if "py3-none-any" not in (wheel_metadata.get_all("Tag") or []):
+                failures.append("wheel_metadata_portable_tag_missing")
 
         registry_name = "stream_attention/policies/registry.json"
         if registry_name in names:

--- a/benchmarks/profile_paged_exact_decode.py
+++ b/benchmarks/profile_paged_exact_decode.py
@@ -1,0 +1,261 @@
+"""Benchmark StreamAttn native paged exact decode against FlashInfer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from stream_attention import PagedExactDecodePlan, PagedKVCache
+
+
+def _dtype(name: str) -> torch.dtype:
+    if name == "fp16":
+        return torch.float16
+    if name == "bf16":
+        return torch.bfloat16
+    raise ValueError("dtype must be fp16 or bf16")
+
+
+def _time_cuda(
+    function: Callable[[], torch.Tensor],
+    *,
+    warmup: int,
+    repeats: int,
+) -> list[float]:
+    for _ in range(warmup):
+        function()
+    torch.cuda.synchronize()
+    samples: list[float] = []
+    for _ in range(repeats):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        function()
+        end.record()
+        end.synchronize()
+        samples.append(float(start.elapsed_time(end)))
+    return samples
+
+
+def _flashinfer_runner(
+    query: torch.Tensor,
+    cache: PagedKVCache,
+    *,
+    workspace_mb: int,
+):
+    try:
+        import flashinfer
+    except Exception as exc:
+        raise RuntimeError("FlashInfer is required for the paired benchmark") from exc
+    if cache.normalized_layout != "NHD":
+        raise ValueError("the paired FlashInfer helper currently requires NHD pages")
+
+    batch = int(query.shape[0])
+    pages_per_request = cache.max_pages_per_request
+    indptr = torch.arange(
+        0,
+        (batch + 1) * pages_per_request,
+        pages_per_request,
+        device=query.device,
+        dtype=torch.int32,
+    )
+    indices = cache.page_table.reshape(-1).to(dtype=torch.int32)
+    last_page_len = (
+        (cache.sequence_lengths - 1) % cache.page_size + 1
+    ).to(dtype=torch.int32)
+    combined_cache = torch.stack((cache.key, cache.value), dim=1).contiguous()
+    workspace = torch.empty(
+        workspace_mb * 1024 * 1024,
+        device=query.device,
+        dtype=torch.uint8,
+    )
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace,
+        "NHD",
+        use_tensor_cores=True,
+        backend="auto",
+    )
+    wrapper.plan(
+        indptr,
+        indices,
+        last_page_len,
+        int(query.shape[2]),
+        cache.kv_heads,
+        int(query.shape[3]),
+        cache.page_size,
+        pos_encoding_mode="NONE",
+        q_data_type=query.dtype,
+        kv_data_type=cache.key.dtype,
+        o_data_type=query.dtype,
+        sm_scale=1.0 / math.sqrt(float(query.shape[3])),
+        disable_split_kv=False,
+    )
+    output = torch.empty(
+        query.shape[0],
+        query.shape[2],
+        query.shape[3],
+        device=query.device,
+        dtype=query.dtype,
+    )
+
+    def run() -> torch.Tensor:
+        return wrapper.run(query[:, 0], combined_cache, out=output)
+
+    return run
+
+
+def profile(args: argparse.Namespace) -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if args.kv_len <= 0 or args.kv_len % args.page_size:
+        raise ValueError("kv_len must be positive and divisible by page_size")
+    if args.q_heads % args.kv_heads:
+        raise ValueError("q_heads must be divisible by kv_heads")
+
+    device = torch.device("cuda")
+    dtype = _dtype(args.dtype)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    pages_per_request = args.kv_len // args.page_size
+    total_pages = args.batch * pages_per_request
+    query = torch.randn(
+        args.batch,
+        1,
+        args.q_heads,
+        args.head_dim,
+        device=device,
+        dtype=dtype,
+    )
+    key = torch.randn(
+        total_pages,
+        args.page_size,
+        args.kv_heads,
+        args.head_dim,
+        device=device,
+        dtype=dtype,
+    )
+    value = torch.randn_like(key)
+    page_table = torch.randperm(
+        total_pages, device=device, dtype=torch.int64
+    ).to(torch.int32).view(args.batch, pages_per_request)
+    sequence_lengths = torch.full(
+        (args.batch,),
+        args.kv_len,
+        device=device,
+        dtype=torch.int32,
+    )
+    cache = PagedKVCache(
+        key=key,
+        value=value,
+        page_table=page_table,
+        sequence_lengths=sequence_lengths,
+        layout="NHD",
+    )
+    plan = PagedExactDecodePlan.build(
+        query,
+        cache,
+        splits=args.splits,
+    )
+    flashinfer_run = _flashinfer_runner(
+        query,
+        cache,
+        workspace_mb=args.workspace_mb,
+    )
+
+    stream_output = plan.run().clone()
+    flashinfer_output = flashinfer_run().view_as(query).clone()
+    torch.cuda.synchronize()
+    max_abs_error = float(
+        (stream_output.float() - flashinfer_output.float()).abs().max().item()
+    )
+    mean_abs_error = float(
+        (stream_output.float() - flashinfer_output.float()).abs().mean().item()
+    )
+    if max_abs_error > args.atol:
+        raise RuntimeError(
+            f"paged exact correctness failed: {max_abs_error} > {args.atol}"
+        )
+
+    stream_samples = _time_cuda(
+        plan.run,
+        warmup=args.warmup,
+        repeats=args.repeats,
+    )
+    flashinfer_samples = _time_cuda(
+        flashinfer_run,
+        warmup=args.warmup,
+        repeats=args.repeats,
+    )
+    stream_ms = float(statistics.median(stream_samples))
+    flashinfer_ms = float(statistics.median(flashinfer_samples))
+    return {
+        "schema": "streamattn.paged_exact_decode_profile.v1",
+        "timestamp_unix": time.time(),
+        "device": torch.cuda.get_device_name(),
+        "compute_capability": list(torch.cuda.get_device_capability()),
+        "torch_version": torch.__version__,
+        "batch": args.batch,
+        "kv_len": args.kv_len,
+        "q_heads": args.q_heads,
+        "kv_heads": args.kv_heads,
+        "group_size": args.q_heads // args.kv_heads,
+        "head_dim": args.head_dim,
+        "dtype": args.dtype,
+        "page_size": args.page_size,
+        "pages_per_request": pages_per_request,
+        "physical_page_order": "randomized",
+        "splits": plan.splits,
+        "producer_ctas": args.batch * args.q_heads * plan.splits,
+        "workspace_bytes": plan.workspace_bytes,
+        "streamattn_ms": stream_ms,
+        "flashinfer_ms": flashinfer_ms,
+        "speedup_vs_flashinfer": flashinfer_ms / stream_ms,
+        "max_abs_error": max_abs_error,
+        "mean_abs_error": mean_abs_error,
+        "warmup": args.warmup,
+        "repeats": args.repeats,
+        "streamattn_samples_ms": stream_samples,
+        "flashinfer_samples_ms": flashinfer_samples,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=4)
+    parser.add_argument("--kv-len", type=int, default=32768)
+    parser.add_argument("--q-heads", type=int, default=16)
+    parser.add_argument("--kv-heads", type=int, default=2)
+    parser.add_argument("--head-dim", type=int, default=64)
+    parser.add_argument("--page-size", type=int, default=16)
+    parser.add_argument("--dtype", choices=("fp16", "bf16"), default="bf16")
+    parser.add_argument("--splits", type=int)
+    parser.add_argument("--workspace-mb", type=int, default=128)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repeats", type=int, default=30)
+    parser.add_argument("--atol", type=float, default=1e-2)
+    parser.add_argument("--seed", type=int, default=17)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+
+    result = profile(args)
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    print(payload)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(payload + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_gpu_correctness_ci.py
+++ b/benchmarks/run_gpu_correctness_ci.py
@@ -1,0 +1,77 @@
+"""Run the contributor GPU correctness suite on an available CUDA device."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+
+
+GENERIC_GPU_TESTS = (
+    "tests/test_gate0_projection_bitmask_triton.py",
+    "tests/test_gate0_projection_mask_triton.py",
+    "tests/test_gate0_projection_scan_triton.py",
+    "tests/test_gate0_summary_scan_triton.py",
+    "tests/test_qwen_o_proj_triton.py",
+    "tests/test_paged_decode.py::test_cuda_paged_exact_matches_dense_and_uses_native_backend",
+    "tests/test_seed_only_split_seed.py::test_split_seed_matches_direct_seed_cuda",
+    "tests/test_seed_only_route_bundle_decode.py::test_exact_refresh_triton_row_subset_matches_reference_when_cuda_available",
+    "tests/test_attention.py::TestStreamAttention::test_fused_online_attention_mask_parity",
+    "tests/test_attention.py::TestStreamAttention::test_fused_online_attention_dropout_determinism",
+    "tests/test_attention.py::TestStreamAttention::test_fused_online_attention_backward_matches_sdpa",
+)
+
+
+def _device_report() -> dict[str, object]:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required; refusing to report a skipped GPU pass")
+    try:
+        import triton
+    except ImportError as exc:
+        raise RuntimeError("Triton is required for the GPU correctness suite") from exc
+
+    device = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device)
+    return {
+        "device": props.name,
+        "compute_capability": list(torch.cuda.get_device_capability(device)),
+        "total_memory_bytes": props.total_memory,
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "triton": triton.__version__,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--require-sm90", action="store_true")
+    parser.add_argument("--cutlass-root", type=Path, default=None)
+    args = parser.parse_args()
+
+    report = _device_report()
+    capability = tuple(report["compute_capability"])
+    if args.require_sm90 and capability != (9, 0):
+        raise RuntimeError(f"SM90 was required, found compute capability {capability}")
+
+    tests = list(GENERIC_GPU_TESTS)
+    if args.require_sm90:
+        if args.cutlass_root is None:
+            raise RuntimeError("--cutlass-root is required with --require-sm90")
+        os.environ["STREAMATTN_CUTLASS_ROOT"] = str(args.cutlass_root.resolve())
+        tests.append(
+            "tests/test_sm90_exact_backend.py::test_promoted_exact_plan_reuses_workspace_and_tracks_query_mutation"
+        )
+
+    print(json.dumps({"schema": "streamattn.gpu_ci_environment.v1", **report}, indent=2))
+    command = [sys.executable, "-m", "pytest", "-q", "-rs", *tests]
+    print("running:", " ".join(command), flush=True)
+    raise SystemExit(subprocess.run(command, check=False).returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_lightning_paged_exact_decode.py
+++ b/benchmarks/run_lightning_paged_exact_decode.py
@@ -1,0 +1,238 @@
+"""Run the paged exact-decode benchmark on Lightning and delete the job."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import os
+import sys
+import tarfile
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from lightning_sdk.api.job_api import JobApiV2
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+BASE_SHA = "fa81ba54d574d3b179c99ba75933112e1f759bd8"
+RESULT_SCHEMA = "streamattn.paged_exact_decode_profile.v1"
+TERMINAL_STATES = {"completed", "failed", "stopped", "cancelled", "error"}
+OVERLAY_PATHS = (
+    "benchmarks/profile_paged_exact_decode.py",
+    "stream_attention/__init__.py",
+    "stream_attention/engine.py",
+    "stream_attention/paged.py",
+    "stream_attention/kernels/paged_exact_triton.py",
+)
+
+
+def _overlay_b64() -> str:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz", compresslevel=9) as archive:
+        for relative in OVERLAY_PATHS:
+            archive.add(REPO_ROOT / relative, arcname=relative)
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def _result_from_logs(logs: str) -> Optional[dict[str, Any]]:
+    decoder = json.JSONDecoder()
+    result = None
+    for start, char in enumerate(logs):
+        if char != "{":
+            continue
+        try:
+            payload, _ = decoder.raw_decode(logs[start:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("schema") == RESULT_SCHEMA:
+            result = payload
+    return result
+
+
+def _fetch_finished_logs(
+    api: JobApiV2,
+    *,
+    job_id: str,
+    teamspace_id: str,
+    attempts: int = 12,
+    delay: float = 10.0,
+) -> str:
+    last_error: Optional[BaseException] = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return api.get_logs_finished(job_id=job_id, teamspace_id=teamspace_id)
+        except Exception as exc:
+            last_error = exc
+            print(
+                f"log fetch attempt {attempt} failed: {type(exc).__name__}",
+                flush=True,
+            )
+            time.sleep(delay)
+    raise RuntimeError(f"could not fetch Lightning logs: {last_error}")
+
+
+def _job_command(args: argparse.Namespace) -> str:
+    payload = _overlay_b64()
+    benchmark = " ".join(
+        [
+            "python -u benchmarks/profile_paged_exact_decode.py",
+            f"--batch {args.batch}",
+            f"--kv-len {args.kv_len}",
+            f"--q-heads {args.q_heads}",
+            f"--kv-heads {args.kv_heads}",
+            f"--head-dim {args.head_dim}",
+            f"--page-size {args.page_size}",
+            f"--dtype {args.dtype}",
+            f"--warmup {args.warmup}",
+            f"--repeats {args.repeats}",
+            f"--atol {args.atol}",
+            "--output-json /tmp/result.json",
+        ]
+    )
+    if args.splits is not None:
+        benchmark += f" --splits {args.splits}"
+    return "\n".join(
+        [
+            "set -eu",
+            "export PYTHONUNBUFFERED=1",
+            "python - <<'PY'\n"
+            "import pathlib, shutil, urllib.request, zipfile\n"
+            f"sha = {BASE_SHA!r}\n"
+            "archive = pathlib.Path('/tmp/streamattn.zip')\n"
+            "dst = pathlib.Path('/root/StreamAttn')\n"
+            "if dst.exists(): shutil.rmtree(dst)\n"
+            "urllib.request.urlretrieve(f'https://github.com/MagellaX/StreamAttn/archive/{sha}.zip', archive)\n"
+            "with zipfile.ZipFile(archive) as zf: zf.extractall('/root')\n"
+            "(pathlib.Path('/root') / f'StreamAttn-{sha}').rename(dst)\n"
+            "PY",
+            "cd /root/StreamAttn",
+            "python - <<'PY'\n"
+            "import base64, io, tarfile\n"
+            f"payload = {payload!r}\n"
+            "with tarfile.open(fileobj=io.BytesIO(base64.b64decode(payload)), mode='r:gz') as archive:\n"
+            "    archive.extractall('.')\n"
+            "PY",
+            "python -m pip install -q flashinfer-python==0.6.12 flashinfer-cubin==0.6.12 ninja",
+            benchmark,
+            "cat /tmp/result.json",
+        ]
+    )
+
+
+def _delete_job(api: JobApiV2, args: argparse.Namespace, job: Any) -> None:
+    try:
+        current = api.get_job(job_id=job.id, teamspace_id=args.teamspace_id)
+        if str(current.state) not in TERMINAL_STATES:
+            api.stop_job(job_id=job.id, teamspace_id=args.teamspace_id)
+            time.sleep(3)
+    except Exception as exc:
+        print(f"warning: stop check failed: {type(exc).__name__}: {exc}", flush=True)
+    try:
+        api.delete_job(job_id=job.id, teamspace_id=args.teamspace_id, cloudspace_id="")
+        print(f"deleted job id={job.id}", flush=True)
+    except Exception as exc:
+        print(f"warning: delete failed: {type(exc).__name__}: {exc}", flush=True)
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    api = JobApiV2()
+    job = None
+    try:
+        job = api.submit_job(
+            name=args.name,
+            command=_job_command(args),
+            cloud_account=args.cloud_account,
+            teamspace_id=args.teamspace_id,
+            studio_id=None,
+            image=args.image,
+            machine=args.machine,
+            interruptible=False,
+            env={"PYTHONUNBUFFERED": "1"},
+            image_credentials=None,
+            cloud_account_auth=False,
+            entrypoint="sh -c",
+            path_mappings=None,
+            artifacts_local=None,
+            artifacts_remote=None,
+            max_runtime=args.max_runtime,
+            reuse_snapshot=False,
+            scratch_disks=None,
+        )
+        print(f"submitted job name={job.name} id={job.id} state={job.state}", flush=True)
+        started = time.time()
+        while True:
+            current = api.get_job(job_id=job.id, teamspace_id=args.teamspace_id)
+            state = str(current.state)
+            print(f"poll elapsed={int(time.time() - started)}s state={state}", flush=True)
+            if state in TERMINAL_STATES:
+                break
+            time.sleep(args.poll_seconds)
+        logs = _fetch_finished_logs(
+            api,
+            job_id=job.id,
+            teamspace_id=args.teamspace_id,
+        )
+        if args.log_path is not None:
+            args.log_path.parent.mkdir(parents=True, exist_ok=True)
+            args.log_path.write_text(logs, encoding="utf-8")
+        if state != "completed":
+            raise RuntimeError(f"Lightning job ended with state={state}")
+        result = _result_from_logs(logs)
+        if result is None:
+            raise RuntimeError("could not parse paged exact-decode result")
+        if args.output_json is not None:
+            args.output_json.parent.mkdir(parents=True, exist_ok=True)
+            args.output_json.write_text(
+                json.dumps(result, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        return result
+    finally:
+        if job is not None:
+            _delete_job(api, args, job)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", default="streamattn-paged-exact-h100")
+    parser.add_argument(
+        "--teamspace-id",
+        default=os.environ.get("LIGHTNING_TEAMSPACE_ID", "01jggw9j5v8ms266vgvgcs3q13"),
+    )
+    parser.add_argument(
+        "--cloud-account",
+        default=os.environ.get("LIGHTNING_CLOUD_ACCOUNT", "lightning-nebius-prod"),
+    )
+    parser.add_argument(
+        "--machine",
+        default=os.environ.get("LIGHTNING_MACHINE", "nb-h100-1gpu-16vcpu-200gb"),
+    )
+    parser.add_argument("--image", default="pytorch/pytorch:2.7.1-cuda12.8-cudnn9-devel")
+    parser.add_argument("--max-runtime", type=int, default=1800)
+    parser.add_argument("--poll-seconds", type=int, default=15)
+    parser.add_argument("--batch", type=int, default=4)
+    parser.add_argument("--kv-len", type=int, default=32768)
+    parser.add_argument("--q-heads", type=int, default=16)
+    parser.add_argument("--kv-heads", type=int, default=2)
+    parser.add_argument("--head-dim", type=int, default=64)
+    parser.add_argument("--page-size", type=int, default=16)
+    parser.add_argument("--dtype", choices=("fp16", "bf16"), default="bf16")
+    parser.add_argument("--splits", type=int)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repeats", type=int, default=30)
+    parser.add_argument("--atol", type=float, default=1e-2)
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--log-path", type=Path)
+    args = parser.parse_args()
+    print(json.dumps(run(args), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/gpu_ci_and_wheels.md
+++ b/docs/gpu_ci_and_wheels.md
@@ -1,0 +1,94 @@
+# GPU CI and Wheel Strategy
+
+StreamAttn separates package construction, CUDA compilation, GPU correctness,
+and performance evidence. These are different claims and must not be collapsed
+into a single green check.
+
+## Wheel model
+
+The current package contains Python, Triton JIT kernels, CUDA extension source,
+and policy JSON. It does not embed a compiled CUDA extension in the wheel. The
+build therefore produces one portable artifact:
+
+```text
+stream_attention-<version>-py3-none-any.whl
+```
+
+That wheel is appropriate for CPU installations and NVIDIA GPU installations.
+The installed PyTorch/Triton/CUDA environment determines runtime support, and
+the SM90 exact backend compiles its specialized extension during planning.
+Separate A100, H100, or B200 wheels would not improve compatibility under this
+source/JIT architecture.
+
+If StreamAttn later ships precompiled native extensions, use Linux manylinux
+wheels with explicit CUDA build variants and a deliberate architecture list.
+Do not relabel a binary extension as `py3-none-any`.
+
+## No-cost automatic checks
+
+Public repositories can use standard GitHub-hosted CPU runners without paying
+for execution. The required `CI` workflow and the path-triggered
+`.github/workflows/gpu-source.yml` workflow use those runners for:
+
+1. importing every shipped Triton module with Triton enabled;
+2. checking the generated D64 and D128 SM90 source contracts;
+3. compiling the SM90 exact and TMA extensions with `nvcc`/`ptxas` for
+   `sm_90a` inside a CUDA development container;
+4. never executing a kernel or claiming hardware correctness.
+
+The offline build catches Python import failures, Triton import/API breakage,
+C++/CUDA syntax errors, CUTLASS incompatibility, and SM90 code-generation
+failures without requiring a GPU.
+
+## Runtime correctness
+
+Standard GitHub-hosted runners do not include an NVIDIA CUDA device. GitHub GPU
+larger runners are billed even for public repositories. Consequently, a no-cost
+central workflow cannot honestly execute StreamAttn CUDA kernels today.
+
+Contributors changing GPU behavior must run the repository-owned harness on a
+GPU they control:
+
+```bash
+python -m pip install -e .[dev,triton]
+python benchmarks/run_gpu_correctness_ci.py
+```
+
+For the promoted H100 exact-native path:
+
+```bash
+python benchmarks/run_gpu_correctness_ci.py \
+  --require-sm90 \
+  --cutlass-root /path/to/FlashMLA-ETAP/csrc/cutlass
+```
+
+Attach the complete output to the pull request. The harness fails immediately
+when CUDA or Triton is unavailable, preventing a skipped test suite from being
+reported as a GPU pass.
+
+## Evidence levels
+
+| Evidence | Automatic | Requires GPU | Merge meaning |
+| --- | --- | --- | --- |
+| Universal wheel and metadata | Yes | No | Package is structurally installable |
+| Triton source contract | Yes | No | GPU Python modules import with Triton |
+| SM90 offline CUDA build | Yes | No | H100 source compiles for `sm_90a` |
+| GPU correctness harness | Contributor evidence | Yes | Selected kernels match references |
+| Performance gate | Maintainer/research evidence | Yes | A measured shape beats its baseline |
+
+Runtime and performance evidence remain mandatory for GPU behavior and speed
+claims. An offline compile pass is not a substitute for either.
+
+## Future donated runner
+
+If the project receives a donated ephemeral GPU runner, connect the same
+`run_gpu_correctness_ci.py` harness rather than introducing a second test list.
+Fork pull requests must remain approval-gated because they execute untrusted
+code. A persistent self-hosted machine must not execute arbitrary public PRs.
+
+References:
+
+- GitHub Actions billing: https://docs.github.com/en/billing/concepts/product-billing/github-actions
+- NVIDIA GPU runner guidance: https://docs.nvidia.com/datascience/deployment/stable/developer/ci/github-actions/
+- PyTorch CUDA extension architecture targeting: https://docs.pytorch.org/docs/main/cpp_extension.html
+- Python wheel compatibility tags: https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/

--- a/docs/paged_exact_decode.md
+++ b/docs/paged_exact_decode.md
@@ -1,0 +1,100 @@
+# Paged Exact Decode
+
+## Status
+
+StreamAttn has an experimental exact decode path that consumes a paged KV cache
+directly. It is wired into the public engine but is not a promoted performance
+route until paired H100 measurements pass.
+
+## Contract
+
+The query is [batch, 1, query_heads, head_dim]. Physical pages use either:
+
+~~~text
+NHD: [num_pages, page_size, kv_heads, head_dim]
+HND: [num_pages, kv_heads, page_size, head_dim]
+~~~
+
+Each request supplies:
+
+~~~text
+page_table:       [batch, max_pages_per_request]
+sequence_lengths: [batch]
+~~~
+
+Trailing page-table slots may contain -1. Every active slot must reference a
+valid physical page. Planning validates the initial metadata once; serving code
+may update the same buffers in place while preserving those invariants.
+
+## Kernel
+
+The Triton backend launches split-K producers over:
+
+~~~text
+[batch, query_heads, splits]
+~~~
+
+Each producer:
+
+1. Loads the query head once.
+2. Walks its logical page interval.
+3. Loads the physical page ID from the block table.
+4. Reads K/V directly from that page.
+5. Maintains FP32 online-softmax state (m, l, numerator).
+6. Writes one compact partial state.
+
+A second kernel merges partial states with the exact online-softmax merge:
+
+~~~text
+m = max_i(m_i)
+l = sum_i(l_i * exp(m_i - m))
+n = sum_i(n_i * exp(m_i - m))
+out = n / l
+~~~
+
+No per-request contiguous KV tensor is created. Workspace and output buffers
+are allocated once by PagedExactDecodePlan.
+
+## Benchmark
+
+Run a paired benchmark against FlashInfer:
+
+~~~bash
+python benchmarks/profile_paged_exact_decode.py \
+  --batch 4 \
+  --kv-len 32768 \
+  --q-heads 16 \
+  --kv-heads 2 \
+  --head-dim 64 \
+  --page-size 16 \
+  --dtype bf16 \
+  --output-json artifacts/paged_exact_b4_32k_d64_g8_h100.json
+~~~
+
+The benchmark randomizes physical page order, checks output parity, reuses both
+plans, and reports paired raw samples. Packing time is excluded for both
+backends because page construction belongs to cache management, not decode.
+
+## Promotion Gate
+
+A cell can be promoted only when:
+
+~~~text
+correctness passes against an exact reference
+paired median speedup > 1.0
+at least 7 of 9 paired trials win
+no page-to-contiguous copy occurs in the timed path
+workspace and output buffers are reused
+~~~
+
+The first matrix is H100, BF16:
+
+~~~text
+B = 1, 2, 4, 8
+N = 16K, 32K, 64K
+D64/G4
+D64/G8
+~~~
+
+D128/G4 follows after the D64 phase diagram identifies whether page-table
+lookup, duplicated GQA reads, or split-state merge is the limiting term.

--- a/stream_attention/__init__.py
+++ b/stream_attention/__init__.py
@@ -15,7 +15,7 @@ Key Features:
 
 __version__ = "1.0.0"
 __author__ = "StreamAttention Team"
-__license__ = "MIT"
+__license__ = "Apache-2.0"
 
 from .core.config import StreamAttentionConfig
 from .core.fused_online_attention import (
@@ -103,6 +103,14 @@ from .engine import (
     stream_attn_decode,
 )
 from .backends.sm90 import ExactDecodePlan
+from .paged import (
+    PAGED_EXACT_NATIVE_BACKEND,
+    PagedExactDecodePlan,
+    PagedKVCache,
+    choose_paged_exact_splits,
+    paged_exact_reference,
+    stream_attn_paged_exact_decode,
+)
 
 # ``import stream_attention as stream_attn; stream_attn.decode(...)``
 decode = stream_attn_decode
@@ -205,6 +213,12 @@ __all__ = [
     "StreamAttnEngine",
     "StreamAttnEnginePlan",
     "ExactDecodePlan",
+    "PAGED_EXACT_NATIVE_BACKEND",
+    "PagedExactDecodePlan",
+    "PagedKVCache",
+    "choose_paged_exact_splits",
+    "paged_exact_reference",
+    "stream_attn_paged_exact_decode",
     "stream_attn_decode",
     "decode",
     "SeedKernelAutotuneResult",

--- a/stream_attention/engine.py
+++ b/stream_attention/engine.py
@@ -26,6 +26,12 @@ from .decode import (
     StreamAttnServingInfo,
     normalize_stream_attn_mode,
 )
+from .paged import (
+    PAGED_EXACT_NATIVE_BACKEND,
+    PagedExactDecodePlan,
+    PagedExactDecodeRunner,
+    PagedKVCache,
+)
 
 
 @dataclass(frozen=True)
@@ -38,11 +44,15 @@ class StreamAttnEnginePlan:
     model_id: Optional[str]
     layer_id: Optional[int]
     query: torch.Tensor
-    key_cache: torch.Tensor
-    value_cache: torch.Tensor
+    key_cache: Union[torch.Tensor, PagedKVCache]
+    value_cache: Optional[torch.Tensor]
     service: StreamAttnSeedOnlyDecodeService
     direct_runner: Optional[
-        Union[StreamAttnSeedOnlyDirectRunner, StreamAttnExactNativeDirectRunner]
+        Union[
+            StreamAttnSeedOnlyDirectRunner,
+            StreamAttnExactNativeDirectRunner,
+            PagedExactDecodeRunner,
+        ]
     ] = None
 
     @property
@@ -58,6 +68,8 @@ class StreamAttnEnginePlan:
                 if return_info
                 else self.direct_runner.run()
             )
+        if self.value_cache is None or not isinstance(self.key_cache, torch.Tensor):
+            raise RuntimeError("non-native plan is missing contiguous KV tensors")
         return self.service.run(
             self.query,
             self.key_cache,
@@ -134,11 +146,71 @@ class StreamAttnEngine:
             direct_runner=direct_runner,
         )
 
+    def _paged_exact_plan(
+        self,
+        *,
+        mode: str,
+        query: torch.Tensor,
+        cache: PagedKVCache,
+    ) -> StreamAttnEnginePlan:
+        if mode == STREAMATTN_MODE_SEED_ONLY_NATIVE:
+            raise ValueError(
+                "seed_only_native does not yet support paged KV; "
+                "use exact_native or verified_auto"
+            )
+        paged_plan = PagedExactDecodePlan.build(query, cache)
+        reason = (
+            "explicit_paged_exact_native"
+            if mode == STREAMATTN_MODE_EXACT_NATIVE
+            else "paged_kv_exact_only"
+        )
+        kv_len = int(cache.sequence_lengths.max().item())
+        backend = paged_plan.backend
+        info = StreamAttnServingInfo(
+            backend_used=backend,
+            policy_id=None,
+            fallback_reason=None,
+            batch_size=int(query.shape[0]),
+            kv_len=kv_len,
+            layer_id=None,
+            model_id=None,
+            dtype=str(query.dtype).removeprefix("torch."),
+            device=str(query.device),
+            plan_backend=backend,
+            plan_reason=reason,
+            seed_only_enabled=False,
+            safety_policy_matched=False,
+            runtime_counters={
+                "backend_counts": {backend: 1},
+                "fallback_reasons": {},
+            },
+            stats={
+                "layout": cache.normalized_layout,
+                "page_size": cache.page_size,
+                "max_pages_per_request": cache.max_pages_per_request,
+                "splits": paged_plan.splits,
+                "workspace_bytes": paged_plan.workspace_bytes,
+            },
+        )
+        runner = PagedExactDecodeRunner(plan=paged_plan, info=info)
+        return StreamAttnEnginePlan(
+            mode=mode,
+            backend=backend,
+            reason=reason,
+            model_id=None,
+            layer_id=None,
+            query=query,
+            key_cache=cache,
+            value_cache=None,
+            service=self.service,
+            direct_runner=runner,
+        )
+
     def plan(
         self,
         query: torch.Tensor,
-        key_cache: torch.Tensor,
-        value_cache: torch.Tensor,
+        key_cache: Union[torch.Tensor, PagedKVCache],
+        value_cache: Optional[torch.Tensor] = None,
         *,
         mode: str = STREAMATTN_MODE_VERIFIED_AUTO,
         model_id: Optional[str] = None,
@@ -147,6 +219,18 @@ class StreamAttnEngine:
         """Validate once and bind a native decode plan to stable buffers."""
 
         normalized_mode = normalize_stream_attn_mode(mode)
+        if isinstance(key_cache, PagedKVCache):
+            if value_cache is not None:
+                raise ValueError(
+                    "value_cache must be omitted when key_cache is PagedKVCache"
+                )
+            return self._paged_exact_plan(
+                mode=normalized_mode,
+                query=query,
+                cache=key_cache,
+            )
+        if value_cache is None:
+            raise ValueError("value_cache is required for contiguous KV decode")
         effective_model_id = model_id if model_id is not None else self.service.model_id
         effective_layer_id = layer_id if layer_id is not None else self.service.layer_id
         if normalized_mode == STREAMATTN_MODE_EXACT_NATIVE:
@@ -197,8 +281,8 @@ class StreamAttnEngine:
     def decode(
         self,
         query: torch.Tensor,
-        key_cache: torch.Tensor,
-        value_cache: torch.Tensor,
+        key_cache: Union[torch.Tensor, PagedKVCache],
+        value_cache: Optional[torch.Tensor] = None,
         *,
         mode: str = STREAMATTN_MODE_VERIFIED_AUTO,
         model_id: Optional[str] = None,
@@ -219,8 +303,8 @@ class StreamAttnEngine:
 
 def stream_attn_decode(
     query: torch.Tensor,
-    key_cache: torch.Tensor,
-    value_cache: torch.Tensor,
+    key_cache: Union[torch.Tensor, PagedKVCache],
+    value_cache: Optional[torch.Tensor] = None,
     *,
     mode: str = STREAMATTN_MODE_VERIFIED_AUTO,
     engine: Optional[StreamAttnEngine] = None,

--- a/stream_attention/kernels/paged_exact_triton.py
+++ b/stream_attention/kernels/paged_exact_triton.py
@@ -1,0 +1,317 @@
+"""Native paged-KV exact decode kernels.
+
+The kernel consumes a block table directly. It never gathers or repacks the
+physical pages into a contiguous per-request cache.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    TRITON_AVAILABLE = True
+except Exception:  # pragma: no cover - environment dependent
+    TRITON_AVAILABLE = False
+
+
+if TRITON_AVAILABLE:
+
+    @triton.jit
+    def _paged_exact_splitk_partial_kernel(
+        Q,
+        K,
+        V,
+        PageTable,
+        SequenceLengths,
+        PartialM,
+        PartialL,
+        PartialNum,
+        Q_STRIDE_B: tl.constexpr,
+        Q_STRIDE_H: tl.constexpr,
+        K_STRIDE_PAGE: tl.constexpr,
+        K_STRIDE_TOKEN: tl.constexpr,
+        K_STRIDE_HEAD: tl.constexpr,
+        V_STRIDE_PAGE: tl.constexpr,
+        V_STRIDE_TOKEN: tl.constexpr,
+        V_STRIDE_HEAD: tl.constexpr,
+        PAGE_TABLE_STRIDE_B: tl.constexpr,
+        H: tl.constexpr,
+        H_KV: tl.constexpr,
+        GROUP_SIZE: tl.constexpr,
+        D: tl.constexpr,
+        NUM_PHYSICAL_PAGES: tl.constexpr,
+        MAX_PAGES: tl.constexpr,
+        PAGE_SIZE: tl.constexpr,
+        PAGE_TILE: tl.constexpr,
+        SPLITS: tl.constexpr,
+        PAGES_PER_SPLIT: tl.constexpr,
+        SCALE: tl.constexpr,
+    ):
+        off_b = tl.program_id(0)
+        off_h = tl.program_id(1)
+        off_split = tl.program_id(2)
+        off_kv_h = off_h // GROUP_SIZE
+        offs_d = tl.arange(0, D)
+        offs_token = tl.arange(0, PAGE_TILE)
+
+        q = tl.load(
+            Q + off_b * Q_STRIDE_B + off_h * Q_STRIDE_H + offs_d
+        ).to(tl.float32)
+        sequence_length = tl.load(SequenceLengths + off_b).to(tl.int32)
+
+        running_max = tl.full([], -float("inf"), dtype=tl.float32)
+        acc_den = tl.zeros([], dtype=tl.float32)
+        acc_num = tl.zeros([D], dtype=tl.float32)
+
+        for local_page in tl.range(0, PAGES_PER_SPLIT):
+            logical_page = off_split * PAGES_PER_SPLIT + local_page
+            page_slot_valid = logical_page < MAX_PAGES
+            physical_page = tl.load(
+                PageTable + off_b * PAGE_TABLE_STRIDE_B + logical_page,
+                mask=page_slot_valid,
+                other=-1,
+            ).to(tl.int64)
+            page_valid = (
+                page_slot_valid
+                & (logical_page * PAGE_SIZE < sequence_length)
+                & (physical_page >= 0)
+                & (physical_page < NUM_PHYSICAL_PAGES)
+            )
+            logical_token = logical_page * PAGE_SIZE + offs_token
+            token_mask = (
+                page_valid
+                & (offs_token < PAGE_SIZE)
+                & (logical_token < sequence_length)
+            )
+
+            k_tile = tl.load(
+                K
+                + physical_page * K_STRIDE_PAGE
+                + offs_token[:, None] * K_STRIDE_TOKEN
+                + off_kv_h * K_STRIDE_HEAD
+                + offs_d[None, :],
+                mask=token_mask[:, None],
+                other=0.0,
+            ).to(tl.float32)
+            scores = tl.sum(q[None, :] * k_tile, axis=1) * SCALE
+            scores = tl.where(token_mask, scores, -float("inf"))
+
+            tile_max = tl.max(scores, axis=0)
+            tile_valid = tile_max > -float("inf")
+            previous_valid = acc_den > 0.0
+            new_valid = previous_valid | tile_valid
+            new_max = tl.maximum(running_max, tile_max)
+            safe_new_max = tl.where(new_valid, new_max, 0.0)
+            correction = tl.where(
+                previous_valid, tl.exp(running_max - safe_new_max), 0.0
+            )
+            probabilities = tl.exp(scores - safe_new_max)
+            probabilities = tl.where(token_mask, probabilities, 0.0)
+
+            v_tile = tl.load(
+                V
+                + physical_page * V_STRIDE_PAGE
+                + offs_token[:, None] * V_STRIDE_TOKEN
+                + off_kv_h * V_STRIDE_HEAD
+                + offs_d[None, :],
+                mask=token_mask[:, None],
+                other=0.0,
+            ).to(tl.float32)
+            acc_num = (
+                acc_num * correction
+                + tl.sum(probabilities[:, None] * v_tile, axis=0)
+            )
+            acc_den = acc_den * correction + tl.sum(probabilities, axis=0)
+            running_max = tl.where(new_valid, new_max, running_max)
+
+        state = (off_b * H + off_h) * SPLITS + off_split
+        tl.store(PartialM + state, running_max)
+        tl.store(PartialL + state, acc_den)
+        tl.store(PartialNum + state * D + offs_d, acc_num)
+
+
+    @triton.jit
+    def _paged_exact_splitk_merge_kernel(
+        PartialM,
+        PartialL,
+        PartialNum,
+        Out,
+        H: tl.constexpr,
+        D: tl.constexpr,
+        SPLITS: tl.constexpr,
+        SPLITS_TILE: tl.constexpr,
+    ):
+        off_b = tl.program_id(0)
+        off_h = tl.program_id(1)
+        offs_split = tl.arange(0, SPLITS_TILE)
+        offs_d = tl.arange(0, D)
+        split_mask = offs_split < SPLITS
+        state = (off_b * H + off_h) * SPLITS
+
+        partial_m = tl.load(
+            PartialM + state + offs_split,
+            mask=split_mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+        partial_l = tl.load(
+            PartialL + state + offs_split,
+            mask=split_mask,
+            other=0.0,
+        ).to(tl.float32)
+        merged_m = tl.max(partial_m, axis=0)
+        valid = merged_m > -float("inf")
+        safe_m = tl.where(valid, merged_m, 0.0)
+        factors = tl.exp(partial_m - safe_m)
+        factors = tl.where(split_mask & (partial_l > 0.0), factors, 0.0)
+        denominator = tl.sum(partial_l * factors, axis=0)
+
+        partial_num = tl.load(
+            PartialNum + (state + offs_split[:, None]) * D + offs_d[None, :],
+            mask=split_mask[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        numerator = tl.sum(partial_num * factors[:, None], axis=0)
+        output = tl.where(denominator > 0.0, numerator / denominator, 0.0)
+        tl.store(Out + off_b * H * D + off_h * D + offs_d, output)
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (int(value) - 1).bit_length()
+
+
+def paged_exact_decode_triton_forward_out(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    layout: str,
+    splits: int,
+    workspace: dict[str, torch.Tensor],
+    partial_num_warps: int = 4,
+    partial_num_stages: int = 2,
+    merge_num_warps: int = 1,
+    merge_num_stages: int = 2,
+) -> torch.Tensor:
+    """Run exact M=1 decode directly over a paged KV cache."""
+
+    if not TRITON_AVAILABLE:
+        raise RuntimeError("Triton is not available")
+    tensors = (
+        query,
+        key_cache,
+        value_cache,
+        page_table,
+        sequence_lengths,
+        output,
+    )
+    if not all(t.is_cuda for t in tensors):
+        raise RuntimeError("paged exact Triton decode requires CUDA tensors")
+    if splits <= 0:
+        raise ValueError("splits must be positive")
+
+    batch, _query_len, heads, dim = map(int, query.shape)
+    normalized_layout = str(layout).upper()
+    if normalized_layout == "NHD":
+        num_pages, page_size, kv_heads, cache_dim = map(int, key_cache.shape)
+        token_stride = int(key_cache.stride(1))
+        head_stride = int(key_cache.stride(2))
+        value_token_stride = int(value_cache.stride(1))
+        value_head_stride = int(value_cache.stride(2))
+    elif normalized_layout == "HND":
+        num_pages, kv_heads, page_size, cache_dim = map(int, key_cache.shape)
+        head_stride = int(key_cache.stride(1))
+        token_stride = int(key_cache.stride(2))
+        value_head_stride = int(value_cache.stride(1))
+        value_token_stride = int(value_cache.stride(2))
+    else:
+        raise ValueError("layout must be NHD or HND")
+    if cache_dim != dim:
+        raise ValueError("query and paged cache head dimensions must match")
+
+    max_pages = int(page_table.shape[1])
+    pages_per_split = (max_pages + int(splits) - 1) // int(splits)
+    page_tile = _next_power_of_2(page_size)
+    score_scale = 1.0 / math.sqrt(float(dim))
+    partial_m = workspace["partial_m"]
+    partial_l = workspace["partial_l"]
+    partial_num = workspace["partial_num"]
+
+    _paged_exact_splitk_partial_kernel[(batch, heads, int(splits))](
+        query,
+        key_cache,
+        value_cache,
+        page_table,
+        sequence_lengths,
+        partial_m,
+        partial_l,
+        partial_num,
+        query.stride(0),
+        query.stride(2),
+        key_cache.stride(0),
+        token_stride,
+        head_stride,
+        value_cache.stride(0),
+        value_token_stride,
+        value_head_stride,
+        page_table.stride(0),
+        H=heads,
+        H_KV=kv_heads,
+        GROUP_SIZE=heads // kv_heads,
+        D=dim,
+        NUM_PHYSICAL_PAGES=num_pages,
+        MAX_PAGES=max_pages,
+        PAGE_SIZE=page_size,
+        PAGE_TILE=page_tile,
+        SPLITS=int(splits),
+        PAGES_PER_SPLIT=pages_per_split,
+        SCALE=score_scale,
+        num_warps=int(partial_num_warps),
+        num_stages=int(partial_num_stages),
+    )
+    _paged_exact_splitk_merge_kernel[(batch, heads)](
+        partial_m,
+        partial_l,
+        partial_num,
+        output,
+        H=heads,
+        D=dim,
+        SPLITS=int(splits),
+        SPLITS_TILE=_next_power_of_2(int(splits)),
+        num_warps=int(merge_num_warps),
+        num_stages=int(merge_num_stages),
+    )
+    return output
+
+
+def make_paged_exact_workspace(
+    *,
+    batch: int,
+    heads: int,
+    splits: int,
+    dim: int,
+    device: torch.device,
+) -> dict[str, torch.Tensor]:
+    """Allocate split-K online-softmax state once during planning."""
+
+    if min(batch, heads, splits, dim) <= 0:
+        raise ValueError("workspace dimensions must be positive")
+    return {
+        "partial_m": torch.empty(
+            batch, heads, splits, device=device, dtype=torch.float32
+        ),
+        "partial_l": torch.empty(
+            batch, heads, splits, device=device, dtype=torch.float32
+        ),
+        "partial_num": torch.empty(
+            batch, heads, splits, dim, device=device, dtype=torch.float32
+        ),
+    }

--- a/stream_attention/paged.py
+++ b/stream_attention/paged.py
@@ -1,0 +1,340 @@
+"""Paged-KV cache contracts and exact decode planning."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import torch
+
+
+PAGED_EXACT_NATIVE_BACKEND = "streamattn_paged_exact_native"
+
+
+@dataclass(frozen=True)
+class PagedKVCache:
+    """Physical KV pages plus a logical request-to-page mapping.
+
+    NHD pages are [num_pages, page_size, kv_heads, head_dim].
+    HND pages are [num_pages, kv_heads, page_size, head_dim].
+    page_table is [batch, max_pages_per_request] and may use -1 for inactive
+    trailing slots. sequence_lengths is [batch].
+    """
+
+    key: torch.Tensor
+    value: torch.Tensor
+    page_table: torch.Tensor
+    sequence_lengths: torch.Tensor
+    layout: str = "NHD"
+
+    @property
+    def normalized_layout(self) -> str:
+        return str(self.layout).upper()
+
+    @property
+    def num_pages(self) -> int:
+        return int(self.key.shape[0]) if self.key.dim() == 4 else 0
+
+    @property
+    def page_size(self) -> int:
+        if self.key.dim() != 4:
+            return 0
+        return int(self.key.shape[1] if self.normalized_layout == "NHD" else self.key.shape[2])
+
+    @property
+    def kv_heads(self) -> int:
+        if self.key.dim() != 4:
+            return 0
+        return int(self.key.shape[2] if self.normalized_layout == "NHD" else self.key.shape[1])
+
+    @property
+    def head_dim(self) -> int:
+        return int(self.key.shape[3]) if self.key.dim() == 4 else 0
+
+    @property
+    def batch_size(self) -> int:
+        return int(self.page_table.shape[0]) if self.page_table.dim() == 2 else 0
+
+    @property
+    def max_pages_per_request(self) -> int:
+        return int(self.page_table.shape[1]) if self.page_table.dim() == 2 else 0
+
+    @property
+    def max_sequence_length(self) -> int:
+        return self.max_pages_per_request * self.page_size
+
+    def validate(
+        self,
+        query: torch.Tensor,
+        *,
+        validate_metadata: bool = True,
+    ) -> None:
+        """Validate shape, device, layout, and active page-table entries."""
+
+        if query.dim() != 4 or query.shape[1] != 1:
+            raise ValueError("paged exact decode query must be [batch, 1, heads, dim]")
+        if self.key.dim() != 4 or self.value.dim() != 4:
+            raise ValueError("paged key/value caches must be rank 4")
+        if self.key.shape != self.value.shape:
+            raise ValueError("paged key/value cache shapes must match")
+        if self.normalized_layout not in {"NHD", "HND"}:
+            raise ValueError("paged KV layout must be NHD or HND")
+        if self.page_table.dim() != 2:
+            raise ValueError("page_table must be [batch, max_pages_per_request]")
+        if self.sequence_lengths.dim() != 1:
+            raise ValueError("sequence_lengths must be [batch]")
+        if self.batch_size != int(query.shape[0]):
+            raise ValueError("query and page_table batch sizes must match")
+        if self.sequence_lengths.numel() != self.batch_size:
+            raise ValueError("sequence_lengths size must match batch")
+        if self.num_pages <= 0 or self.page_size <= 0 or self.max_pages_per_request <= 0:
+            raise ValueError("paged cache dimensions must be positive")
+        if self.page_size > 256:
+            raise ValueError("paged exact decode currently supports page_size <= 256")
+        if self.head_dim != int(query.shape[3]):
+            raise ValueError("query and paged cache head dimensions must match")
+        if self.kv_heads <= 0 or int(query.shape[2]) % self.kv_heads:
+            raise ValueError("query heads must be a multiple of KV heads")
+        if self.head_dim > 256 or self.head_dim & (self.head_dim - 1):
+            raise ValueError("head_dim must be a power of two no larger than 256")
+        if query.dtype != self.key.dtype or query.dtype != self.value.dtype:
+            raise ValueError("query and paged key/value dtypes must match")
+        if not torch.is_floating_point(query):
+            raise ValueError("query and paged key/value tensors must be floating point")
+        if self.page_table.dtype not in {torch.int32, torch.int64}:
+            raise ValueError("page_table must use int32 or int64")
+        if self.sequence_lengths.dtype not in {torch.int32, torch.int64}:
+            raise ValueError("sequence_lengths must use int32 or int64")
+        tensors = (
+            query,
+            self.key,
+            self.value,
+            self.page_table,
+            self.sequence_lengths,
+        )
+        if len({str(t.device) for t in tensors}) != 1:
+            raise ValueError("query and paged cache metadata must share a device")
+        if not all(t.is_contiguous() for t in tensors):
+            raise ValueError("query and paged cache tensors must be contiguous")
+
+        if not validate_metadata:
+            return
+        lengths = self.sequence_lengths.detach().to(device="cpu", dtype=torch.int64)
+        if bool(torch.any(lengths <= 0)):
+            raise ValueError("sequence_lengths must be positive")
+        if bool(torch.any(lengths > self.max_sequence_length)):
+            raise ValueError("sequence_lengths exceed page_table capacity")
+        table = self.page_table.detach().to(device="cpu", dtype=torch.int64)
+        for batch_idx, length in enumerate(lengths.tolist()):
+            active_pages = (int(length) + self.page_size - 1) // self.page_size
+            active = table[batch_idx, :active_pages]
+            if bool(torch.any(active < 0)) or bool(torch.any(active >= self.num_pages)):
+                raise ValueError("active page_table entries must reference physical pages")
+
+
+def choose_paged_exact_splits(
+    *,
+    batch: int,
+    query_heads: int,
+    max_pages_per_request: int,
+    target_ctas: int = 256,
+    max_splits: int = 32,
+) -> int:
+    """Choose the minimum split count needed to expose enough producer CTAs."""
+
+    if min(batch, query_heads, max_pages_per_request, target_ctas, max_splits) <= 0:
+        raise ValueError("paged split inputs must be positive")
+    needed = (target_ctas + batch * query_heads - 1) // (batch * query_heads)
+    return max(1, min(max_pages_per_request, max_splits, needed))
+
+
+def paged_exact_reference(
+    query: torch.Tensor,
+    cache: PagedKVCache,
+    *,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Page-streaming exact reference that does not build a contiguous cache."""
+
+    cache.validate(query)
+    if output is None:
+        output = torch.empty_like(query)
+    if output.shape != query.shape or output.dtype != query.dtype:
+        raise ValueError("output must match query shape and dtype")
+    if output.device != query.device or not output.is_contiguous():
+        raise ValueError("output must be contiguous and share the query device")
+
+    batch, _query_len, heads, dim = map(int, query.shape)
+    group_size = heads // cache.kv_heads
+    scale = 1.0 / math.sqrt(float(dim))
+    for batch_idx in range(batch):
+        sequence_length = int(cache.sequence_lengths[batch_idx].item())
+        active_pages = (sequence_length + cache.page_size - 1) // cache.page_size
+        for head_idx in range(heads):
+            kv_head = head_idx // group_size
+            q = query[batch_idx, 0, head_idx].float()
+            running_max = torch.tensor(
+                -float("inf"), device=query.device, dtype=torch.float32
+            )
+            denominator = torch.zeros((), device=query.device, dtype=torch.float32)
+            numerator = torch.zeros(dim, device=query.device, dtype=torch.float32)
+            for logical_page in range(active_pages):
+                physical_page = int(cache.page_table[batch_idx, logical_page].item())
+                valid_tokens = min(
+                    cache.page_size,
+                    sequence_length - logical_page * cache.page_size,
+                )
+                if cache.normalized_layout == "NHD":
+                    key_page = cache.key[physical_page, :valid_tokens, kv_head]
+                    value_page = cache.value[physical_page, :valid_tokens, kv_head]
+                else:
+                    key_page = cache.key[physical_page, kv_head, :valid_tokens]
+                    value_page = cache.value[physical_page, kv_head, :valid_tokens]
+                scores = torch.matmul(key_page.float(), q) * scale
+                page_max = torch.max(scores)
+                new_max = torch.maximum(running_max, page_max)
+                correction = torch.exp(running_max - new_max)
+                probabilities = torch.exp(scores - new_max)
+                numerator = (
+                    numerator * correction
+                    + torch.sum(probabilities[:, None] * value_page.float(), dim=0)
+                )
+                denominator = denominator * correction + probabilities.sum()
+                running_max = new_max
+            output[batch_idx, 0, head_idx].copy_(
+                (numerator / denominator).to(output.dtype)
+            )
+    return output
+
+
+@dataclass
+class PagedExactDecodePlan:
+    """Allocation-free exact decode plan bound to paged KV buffers."""
+
+    query: torch.Tensor
+    cache: PagedKVCache
+    output: torch.Tensor
+    splits: int
+    workspace: Optional[dict[str, torch.Tensor]]
+    backend: str
+    launch: Optional[Any] = None
+
+    @classmethod
+    def build(
+        cls,
+        query: torch.Tensor,
+        cache: PagedKVCache,
+        *,
+        output: Optional[torch.Tensor] = None,
+        splits: Optional[int] = None,
+        validate_metadata: bool = True,
+    ) -> "PagedExactDecodePlan":
+        cache.validate(query, validate_metadata=validate_metadata)
+        if output is None:
+            output = torch.empty_like(query)
+        if output.shape != query.shape or output.dtype != query.dtype:
+            raise ValueError("output must match query shape and dtype")
+        if output.device != query.device or not output.is_contiguous():
+            raise ValueError("output must be contiguous and share the query device")
+
+        selected_splits = (
+            choose_paged_exact_splits(
+                batch=int(query.shape[0]),
+                query_heads=int(query.shape[2]),
+                max_pages_per_request=cache.max_pages_per_request,
+            )
+            if splits is None
+            else int(splits)
+        )
+        if selected_splits <= 0 or selected_splits > cache.max_pages_per_request:
+            raise ValueError("splits must be in [1, max_pages_per_request]")
+
+        if query.is_cuda:
+            from .kernels.paged_exact_triton import (
+                TRITON_AVAILABLE,
+                make_paged_exact_workspace,
+                paged_exact_decode_triton_forward_out,
+            )
+
+            if not TRITON_AVAILABLE:
+                raise RuntimeError("Triton is required for CUDA paged exact decode")
+            workspace = make_paged_exact_workspace(
+                batch=int(query.shape[0]),
+                heads=int(query.shape[2]),
+                splits=selected_splits,
+                dim=int(query.shape[3]),
+                device=query.device,
+            )
+            return cls(
+                query=query,
+                cache=cache,
+                output=output,
+                splits=selected_splits,
+                workspace=workspace,
+                backend=PAGED_EXACT_NATIVE_BACKEND,
+                launch=paged_exact_decode_triton_forward_out,
+            )
+        return cls(
+            query=query,
+            cache=cache,
+            output=output,
+            splits=1,
+            workspace=None,
+            backend="torch_paged_exact_reference",
+        )
+
+    @property
+    def workspace_bytes(self) -> int:
+        if self.workspace is None:
+            return 0
+        return sum(t.numel() * t.element_size() for t in self.workspace.values())
+
+    def run(self) -> torch.Tensor:
+        """Execute using the bound buffers and preallocated workspace."""
+
+        if self.launch is None:
+            return paged_exact_reference(self.query, self.cache, output=self.output)
+        assert self.workspace is not None
+        return self.launch(
+            self.query,
+            self.cache.key,
+            self.cache.value,
+            self.cache.page_table,
+            self.cache.sequence_lengths,
+            self.output,
+            layout=self.cache.normalized_layout,
+            splits=self.splits,
+            workspace=self.workspace,
+        )
+
+
+@dataclass
+class PagedExactDecodeRunner:
+    """Engine-compatible paged exact runner with serving telemetry."""
+
+    plan: PagedExactDecodePlan
+    info: Any
+
+    def run(self) -> torch.Tensor:
+        return self.plan.run()
+
+    def run_with_info(self):
+        return self.run(), self.info
+
+
+def stream_attn_paged_exact_decode(
+    query: torch.Tensor,
+    cache: PagedKVCache,
+    *,
+    output: Optional[torch.Tensor] = None,
+    splits: Optional[int] = None,
+) -> torch.Tensor:
+    """Plan and execute one exact paged-KV decode call."""
+
+    return PagedExactDecodePlan.build(
+        query,
+        cache,
+        output=output,
+        splits=splits,
+    ).run()

--- a/tests/test_paged_decode.py
+++ b/tests/test_paged_decode.py
@@ -1,0 +1,185 @@
+import math
+
+import pytest
+import torch
+
+import stream_attention as stream_attn
+from stream_attention.paged import (
+    PAGED_EXACT_NATIVE_BACKEND,
+    PagedExactDecodePlan,
+    PagedKVCache,
+    choose_paged_exact_splits,
+    paged_exact_reference,
+)
+
+
+def _make_paged_inputs(*, layout: str = "NHD", device: str = "cpu"):
+    torch.manual_seed(17)
+    batch = 2
+    query_heads = 4
+    kv_heads = 2
+    dim = 8
+    page_size = 4
+    num_pages = 5
+    query = torch.randn(
+        batch, 1, query_heads, dim, device=device, dtype=torch.float32
+    )
+    key_nhd = torch.randn(
+        num_pages, page_size, kv_heads, dim, device=device, dtype=torch.float32
+    )
+    value_nhd = torch.randn_like(key_nhd)
+    page_table = torch.tensor(
+        [[3, 0, -1], [1, 4, 2]], device=device, dtype=torch.int32
+    )
+    sequence_lengths = torch.tensor([7, 10], device=device, dtype=torch.int32)
+    if layout == "NHD":
+        key, value = key_nhd, value_nhd
+    else:
+        key = key_nhd.permute(0, 2, 1, 3).contiguous()
+        value = value_nhd.permute(0, 2, 1, 3).contiguous()
+    cache = PagedKVCache(
+        key=key,
+        value=value,
+        page_table=page_table,
+        sequence_lengths=sequence_lengths,
+        layout=layout,
+    )
+    return query, cache
+
+
+def _dense_expected(query: torch.Tensor, cache: PagedKVCache) -> torch.Tensor:
+    output = torch.empty_like(query)
+    group_size = query.shape[2] // cache.kv_heads
+    scale = 1.0 / math.sqrt(float(query.shape[3]))
+    for batch_idx in range(query.shape[0]):
+        sequence_length = int(cache.sequence_lengths[batch_idx].item())
+        pages = []
+        active_pages = (sequence_length + cache.page_size - 1) // cache.page_size
+        for logical_page in range(active_pages):
+            physical_page = int(cache.page_table[batch_idx, logical_page].item())
+            if cache.normalized_layout == "NHD":
+                pages.append(cache.key[physical_page])
+            else:
+                pages.append(cache.key[physical_page].transpose(0, 1))
+        keys = torch.cat(pages, dim=0)[:sequence_length]
+        pages = []
+        for logical_page in range(active_pages):
+            physical_page = int(cache.page_table[batch_idx, logical_page].item())
+            if cache.normalized_layout == "NHD":
+                pages.append(cache.value[physical_page])
+            else:
+                pages.append(cache.value[physical_page].transpose(0, 1))
+        values = torch.cat(pages, dim=0)[:sequence_length]
+        for head_idx in range(query.shape[2]):
+            kv_head = head_idx // group_size
+            scores = (
+                keys[:, kv_head].float() @ query[batch_idx, 0, head_idx].float()
+            ) * scale
+            output[batch_idx, 0, head_idx] = (
+                scores.softmax(dim=0)[:, None] * values[:, kv_head].float()
+            ).sum(dim=0)
+    return output
+
+
+@pytest.mark.parametrize("layout", ["NHD", "HND"])
+def test_paged_reference_matches_dense_without_repacking_runtime(layout):
+    query, cache = _make_paged_inputs(layout=layout)
+
+    output = paged_exact_reference(query, cache)
+    expected = _dense_expected(query, cache)
+
+    torch.testing.assert_close(output, expected, atol=1e-6, rtol=1e-5)
+
+
+def test_paged_plan_reuses_output_and_observes_page_mutation():
+    query, cache = _make_paged_inputs()
+    plan = PagedExactDecodePlan.build(query, cache)
+
+    first = plan.run().clone()
+    output_pointer = plan.output.data_ptr()
+    cache.key[3].add_(0.5)
+    second = plan.run()
+
+    assert second.data_ptr() == output_pointer
+    assert not torch.equal(first, second)
+    assert plan.workspace_bytes == 0
+    assert plan.backend == "torch_paged_exact_reference"
+
+
+def test_public_decode_accepts_paged_cache_and_verified_auto_fails_closed_exact():
+    query, cache = _make_paged_inputs()
+
+    output, info = stream_attn.decode(query, cache, mode="verified_auto")
+    expected = _dense_expected(query, cache)
+
+    torch.testing.assert_close(output, expected, atol=1e-6, rtol=1e-5)
+    assert info.backend_used == "torch_paged_exact_reference"
+    assert info.plan_reason == "paged_kv_exact_only"
+    assert info.seed_only_enabled is False
+    assert info.stats["page_size"] == 4
+
+
+def test_public_decode_rejects_seed_only_and_redundant_value_cache():
+    query, cache = _make_paged_inputs()
+
+    with pytest.raises(ValueError, match="does not yet support paged KV"):
+        stream_attn.decode(query, cache, mode="seed_only_native")
+    with pytest.raises(ValueError, match="value_cache must be omitted"):
+        stream_attn.decode(query, cache, torch.empty_like(query), mode="exact_native")
+
+
+def test_paged_metadata_validation_rejects_bad_active_page_and_length():
+    query, cache = _make_paged_inputs()
+    bad_table = cache.page_table.clone()
+    bad_table[0, 1] = cache.num_pages
+    bad_page_cache = PagedKVCache(
+        cache.key,
+        cache.value,
+        bad_table,
+        cache.sequence_lengths,
+        cache.layout,
+    )
+    with pytest.raises(ValueError, match="active page_table"):
+        bad_page_cache.validate(query)
+
+    bad_lengths = cache.sequence_lengths.clone()
+    bad_lengths[1] = cache.max_sequence_length + 1
+    bad_length_cache = PagedKVCache(
+        cache.key,
+        cache.value,
+        cache.page_table,
+        bad_lengths,
+        cache.layout,
+    )
+    with pytest.raises(ValueError, match="exceed page_table capacity"):
+        bad_length_cache.validate(query)
+
+
+def test_paged_split_rule_targets_producer_parallelism():
+    assert choose_paged_exact_splits(
+        batch=1, query_heads=16, max_pages_per_request=2048
+    ) == 16
+    assert choose_paged_exact_splits(
+        batch=4, query_heads=16, max_pages_per_request=2048
+    ) == 4
+    assert choose_paged_exact_splits(
+        batch=8, query_heads=16, max_pages_per_request=2048
+    ) == 2
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="requires CUDA",
+)
+def test_cuda_paged_exact_matches_dense_and_uses_native_backend():
+    from stream_attention.kernels.paged_exact_triton import TRITON_AVAILABLE
+
+    if not TRITON_AVAILABLE:
+        pytest.skip("requires Triton")
+    query, cache = _make_paged_inputs(device="cuda")
+    output, info = stream_attn.decode(query, cache, mode="exact_native")
+    expected = _dense_expected(query, cache)
+
+    torch.testing.assert_close(output, expected, atol=2e-4, rtol=2e-4)
+    assert info.backend_used == PAGED_EXACT_NATIVE_BACKEND
+    assert info.stats["workspace_bytes"] > 0

--- a/tests/test_policy_integrity_checks.py
+++ b/tests/test_policy_integrity_checks.py
@@ -59,8 +59,24 @@ Project-URL: Repository, https://github.com/MagellaX/StreamAttn
         archive.writestr("stream_attention/__init__.py", "")
         archive.writestr("stream_attention/policies/registry.json", "not-json")
         archive.writestr("stream_attention-1.0.0.dist-info/METADATA", metadata)
-        archive.writestr("stream_attention-1.0.0.dist-info/WHEEL", "Wheel-Version: 1.0\n")
+        archive.writestr(
+            "stream_attention-1.0.0.dist-info/WHEEL",
+            "Wheel-Version: 1.0\nTag: py3-none-any\n",
+        )
 
     result = check_wheel(wheel)
 
     assert "registry_json_invalid" in result["failures"]
+
+
+def test_wheel_checker_rejects_platform_tag(tmp_path: Path):
+    wheel = tmp_path / "stream_attention-1.0.0-cp311-cp311-linux_x86_64.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("stream_attention/__init__.py", "")
+
+    result = check_wheel(wheel)
+
+    assert any(
+        failure.startswith("wheel_tag_not_portable:")
+        for failure in result["failures"]
+    )


### PR DESCRIPTION
## Summary
- add first-class exact decode over NHD/HND paged KV caches with direct page-table traversal and exact split-state online-softmax merging
- expose paged planning through `stream_attn.decode(...)`, including fixed output/workspace reuse and fail-closed `verified_auto`
- add paired FlashInfer profiling, contributor GPU correctness harnesses, portable wheel validation, and offline SM90 source compilation
- rewrite the README around the actual engine surface, measured evidence, limitations, and contribution workflow

## Validation
- `python -m pytest -q` -> 301 passed, 37 skipped
- focused paged/engine/policy tests -> 15 passed, 2 skipped
- policy route smoke -> passed
- `python -m build` -> wheel and sdist built
- `python -m twine check dist/*` -> passed
- wheel contents check -> passed
- `git diff --check` -> passed

## Hardware evidence status
Lightning rejected the H100 submission before job creation because the account requires a verified payment method for GPU compute. No GPU job remains running. The paged backend is deliberately documented as experimental until paired H100 correctness/performance gates pass; this PR makes no paged speed claim.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class exact decode over paged KV caches and integrates it into the engine; introduces contributor GPU gates and portable wheel checks. Fixes standalone SM90 compile-checker imports to keep the offline CUDA build green.

- Exposes paged planning and execution: `PagedKVCache`, `PagedExactDecodePlan`, `choose_paged_exact_splits`, `stream_attn_paged_exact_decode`; `StreamAttnEngine` and `decode(...)` select the paged-native backend when given a `PagedKVCache` (contiguous decode unchanged).
- Provides Triton split-K kernels for paged exact decode with fixed output/workspace reuse and fail-closed `verified_auto`.
- Adds tests validating paged exact decode parity and a contributor GPU correctness harness (`benchmarks/run_gpu_correctness_ci.py`).
- Adds `CUDA Source Build` workflow and a GPU source-contract CI job that validate Triton imports and offline SM90 CUDA compilation; fixes `benchmarks/check_sm90_cuda_compile.py` imports for standalone runs.
- Enforces a portable `py3-none-any` wheel and expected source layout; updates license to Apache-2.0; adds docs and profiling/Lightning scripts.

**Review and rollout**
- No migration for existing users. To enable paged decode, build a `PagedKVCache` with NHD/HND pages, a `[batch, max_pages]` `page_table` (use -1 for inactive), and `[batch]` `sequence_lengths`, then pass it to `decode(...)`.
- Contributors changing Triton/SM90 code must ensure `CUDA Source Build` and the GPU source-contract job pass, and attach `python benchmarks/run_gpu_correctness_ci.py` results.

<sup>Written for commit e496bf7880d0f068bd7ed07aadfdc832aea16d9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MagellaX/StreamAttn/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

